### PR TITLE
Replace raster favicon assets with SVG icons

### DIFF
--- a/public/icons/aurora-icon-192.svg
+++ b/public/icons/aurora-icon-192.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192" role="img" aria-labelledby="title desc">
+  <title id="title">Aurora Nexus Emblem</title>
+  <desc id="desc">Rounded square with aurora inspired gradients and a luminous arc.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#0b1120" />
+      <stop offset="50%" stop-color="#1d2f5d" />
+      <stop offset="100%" stop-color="#38bdf8" />
+    </linearGradient>
+    <linearGradient id="aurora" x1="10%" y1="80%" x2="90%" y2="20%">
+      <stop offset="0%" stop-color="#f472b6" stop-opacity="0.85" />
+      <stop offset="100%" stop-color="#c084fc" stop-opacity="0.95" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="30%" r="60%">
+      <stop offset="0%" stop-color="#e0f2fe" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#38bdf8" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect x="8" y="8" width="176" height="176" rx="48" fill="url(#bg)" />
+  <path fill="url(#aurora)" d="M40 122c16-30 46-60 82-72 20-6 36-4 46 3 12 8 16 23 5 36-8 10-26 16-42 14-20-3-38 5-51 18-12 11-26 13-40 1z" opacity="0.85" />
+  <path fill="url(#glow)" d="M48 54c28-20 92-36 112-18 9 9 3 24-14 31-38 16-74 14-98-13z" />
+  <path fill="#f8fafc" d="M58 118c15-18 33-30 52-35 22-6 41-1 56 11-15 7-32 9-49 11-19 3-38 7-59 13z" opacity="0.8" />
+</svg>

--- a/public/icons/aurora-icon-512.svg
+++ b/public/icons/aurora-icon-512.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">Aurora Nexus Emblem Large</title>
+  <desc id="desc">Large rounded square representing the Aurora Nexus skyline glow.</desc>
+  <defs>
+    <linearGradient id="bg512" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#020617" />
+      <stop offset="45%" stop-color="#1e3a8a" />
+      <stop offset="100%" stop-color="#38bdf8" />
+    </linearGradient>
+    <linearGradient id="aurora512" x1="10%" y1="85%" x2="90%" y2="15%">
+      <stop offset="0%" stop-color="#f472b6" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#c084fc" stop-opacity="0.9" />
+    </linearGradient>
+    <radialGradient id="glow512" cx="55%" cy="28%" r="65%">
+      <stop offset="0%" stop-color="#f8fafc" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#bae6fd" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect x="36" y="36" width="440" height="440" rx="140" fill="url(#bg512)" />
+  <path fill="url(#aurora512)" d="M112 330c42-80 122-154 218-185 54-17 99-15 131 9 34 25 40 72 11 110-29 36-89 58-146 48-56-11-111 14-150 52-32 32-70 40-112-2z" opacity="0.85" />
+  <path fill="url(#glow512)" d="M120 150c74-52 240-94 296-46 25 23 9 61-38 80-101 41-195 36-258-34z" />
+  <path fill="#f8fafc" d="M150 324c38-46 88-76 138-90 60-17 111-3 153 30-42 18-86 25-134 30-53 6-108 17-157 30z" opacity="0.78" />
+</svg>

--- a/public/icons/aurora-icon-maskable.svg
+++ b/public/icons/aurora-icon-maskable.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">Aurora Nexus Maskable Icon</title>
+  <desc id="desc">Maskable variant of the Aurora Nexus icon with safe padding.</desc>
+  <defs>
+    <linearGradient id="maskable-bg" x1="15%" y1="100%" x2="85%" y2="0%">
+      <stop offset="0%" stop-color="#020617" />
+      <stop offset="35%" stop-color="#172554" />
+      <stop offset="100%" stop-color="#0ea5e9" />
+    </linearGradient>
+    <linearGradient id="maskable-aurora" x1="0%" y1="75%" x2="100%" y2="25%">
+      <stop offset="0%" stop-color="#f472b6" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#a855f7" stop-opacity="0.9" />
+    </linearGradient>
+    <radialGradient id="maskable-glow" cx="50%" cy="32%" r="55%">
+      <stop offset="0%" stop-color="#f1f5f9" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#bae6fd" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect x="0" y="0" width="512" height="512" rx="140" fill="url(#maskable-bg)" />
+  <path fill="url(#maskable-aurora)" d="M96 344c50-88 144-170 256-205 56-18 108-12 136 14 32 30 32 84-9 120-38 34-108 54-172 40-64-15-124 22-164 68-18 18-38 24-47 23-16-3-24-22 0-60z" opacity="0.85" />
+  <path fill="url(#maskable-glow)" d="M118 156c80-50 252-96 314-42 19 16 14 46-26 67-108 56-210 50-288-25z" />
+  <path fill="#f8fafc" d="M148 324c42-48 94-80 148-94 62-18 114-6 154 26-44 18-90 26-138 32-56 8-112 20-164 36z" opacity="0.75" />
+</svg>

--- a/public/icons/aurora-icon.svg
+++ b/public/icons/aurora-icon.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
+  <title id="title">Aurora Nexus Icon</title>
+  <desc id="desc">Aurora gradient emblem for the Aurora Nexus Skyhaven hotel.</desc>
+  <defs>
+    <linearGradient id="bg256" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#020617" />
+      <stop offset="45%" stop-color="#1d4ed8" />
+      <stop offset="100%" stop-color="#38bdf8" />
+    </linearGradient>
+    <linearGradient id="aurora256" x1="12%" y1="82%" x2="88%" y2="18%">
+      <stop offset="0%" stop-color="#f472b6" stop-opacity="0.88" />
+      <stop offset="100%" stop-color="#c084fc" stop-opacity="0.92" />
+    </linearGradient>
+    <radialGradient id="glow256" cx="52%" cy="30%" r="60%">
+      <stop offset="0%" stop-color="#f8fafc" stop-opacity="0.92" />
+      <stop offset="100%" stop-color="#bae6fd" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect x="12" y="12" width="232" height="232" rx="68" fill="url(#bg256)" />
+  <path fill="url(#aurora256)" d="M52 164c24-46 70-90 126-108 32-10 59-7 76 7 19 15 22 44 2 66-16 18-50 29-78 24-32-6-60 8-80 30-18 18-40 24-64-19z" opacity="0.86" />
+  <path fill="url(#glow256)" d="M60 80c42-28 142-52 176-24 15 13 8 36-20 48-60 24-118 22-156-24z" />
+  <path fill="#f8fafc" d="M72 158c20-24 46-40 74-48 32-10 58-3 80 16-22 10-46 14-72 16-28 3-58 9-82 16z" opacity="0.78" />
+</svg>

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,0 +1,29 @@
+{
+  "name": "Aurora Nexus Skyhaven",
+  "short_name": "Aurora Nexus",
+  "description": "Aurora Nexus Skyhaven – a futuristic sanctuary for travellers beyond tomorrow.",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0b1120",
+  "theme_color": "#0ea5e9",
+  "icons": [
+    {
+      "src": "/icons/aurora-icon-192.svg",
+      "type": "image/svg+xml",
+      "sizes": "192x192",
+      "purpose": "any"
+    },
+    {
+      "src": "/icons/aurora-icon-512.svg",
+      "type": "image/svg+xml",
+      "sizes": "512x512",
+      "purpose": "any"
+    },
+    {
+      "src": "/icons/aurora-icon-maskable.svg",
+      "type": "image/svg+xml",
+      "sizes": "512x512",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/views/partials/head.ejs
+++ b/views/partials/head.ejs
@@ -9,6 +9,11 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600;700&family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="/css/styles.css" />
+  <link rel="manifest" href="/site.webmanifest" />
+  <link rel="icon" type="image/svg+xml" href="/icons/aurora-icon.svg" />
+  <link rel="alternate icon" type="image/svg+xml" sizes="192x192" href="/icons/aurora-icon-192.svg" />
+  <link rel="mask-icon" href="/icons/aurora-icon-maskable.svg" color="#0ea5e9" />
+  <link rel="apple-touch-icon" type="image/svg+xml" sizes="192x192" href="/icons/aurora-icon-192.svg" />
   <meta name="csrf-token" content="<%= csrfToken %>" />
   <script defer src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" integrity="sha512-Nd3XoqBYwygJyI072QtdgQXl3k5ufADG7n2AFD+a83H8XTur2qxGn8pY/+bexdFv+DE5jBqFaUG2RgxN+E466Q==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script defer src="/socket.io/socket.io.js"></script>


### PR DESCRIPTION
## Summary
- add SVG-based favicon artwork to replace the prior binary assets
- register the new icons in the HTML head partial and the web manifest

## Testing
- npm start
- curl -I http://127.0.0.1:3000/icons/aurora-icon.svg
- curl -s http://127.0.0.1:3000/site.webmanifest

------
https://chatgpt.com/codex/tasks/task_e_68dcd095698c83238928274c1a26ff27