### PR TITLE
Enhance mobile navigation experience

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -88,6 +88,12 @@ body.app-body {
   font-size: 1.4rem;
 }
 
+.nav-panel {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
 .primary-nav {
   display: flex;
   gap: 1.2rem;
@@ -133,6 +139,75 @@ body.app-body {
   display: flex;
   gap: 0.8rem;
   align-items: center;
+}
+
+.nav-toggle {
+  position: relative;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 50%;
+  border: 1px solid rgba(94, 252, 255, 0.4);
+  background: rgba(8, 12, 30, 0.4);
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+[data-theme='light'] .nav-toggle {
+  background: rgba(255, 255, 255, 0.8);
+  border-color: rgba(17, 22, 51, 0.15);
+}
+
+.nav-toggle:hover,
+.nav-toggle:focus-visible {
+  transform: translateY(-1px);
+}
+
+.nav-toggle-bar {
+  display: block;
+  width: 1.15rem;
+  height: 2px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--color-primary), var(--color-secondary));
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.nav-toggle-bar + .nav-toggle-bar {
+  margin-top: 0.25rem;
+}
+
+.nav-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(5, 1, 20, 0.68);
+  backdrop-filter: blur(12px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.35s ease;
+  z-index: 9;
+}
+
+body.nav-open {
+  overflow: hidden;
+}
+
+.site-header.is-nav-open + .nav-backdrop {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.site-header.is-nav-open .nav-toggle .nav-toggle-bar:nth-of-type(3) {
+  opacity: 0;
+}
+
+.site-header.is-nav-open .nav-toggle .nav-toggle-bar:nth-of-type(2) {
+  transform: translateY(0.27rem) rotate(45deg);
+}
+
+.site-header.is-nav-open .nav-toggle .nav-toggle-bar:nth-of-type(4) {
+  transform: translateY(-0.27rem) rotate(-45deg);
 }
 
 .logout-form {
@@ -1561,6 +1636,11 @@ tr.is-low .inventory-pill {
     align-items: stretch;
   }
 
+  .footer-newsletter-form input[type='email'] {
+    flex: none;
+    width: 100%;
+  }
+
   .footer-newsletter-form button {
     width: 100%;
   }
@@ -1589,13 +1669,67 @@ tr.is-low .inventory-pill {
 
 @media (max-width: 900px) {
   .site-header {
-    flex-wrap: wrap;
-    gap: 1rem;
+    padding: 1rem 1.6rem;
+    gap: 0.75rem;
   }
+
+  .nav-toggle {
+    display: inline-flex;
+  }
+
+  .nav-panel {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: min(320px, 82vw);
+    background: var(--color-surface-alt);
+    backdrop-filter: blur(20px);
+    box-shadow: var(--shadow-elevated);
+    border-left: 1px solid rgba(94, 252, 255, 0.2);
+    padding: 5.4rem 1.75rem 2rem;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1.6rem;
+    transform: translateX(100%);
+    transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+    z-index: 10;
+  }
+
+  [data-theme='light'] .nav-panel {
+    background: rgba(255, 255, 255, 0.92);
+    border-left: 1px solid rgba(17, 22, 51, 0.1);
+  }
+
+  .site-header.is-nav-open .nav-panel {
+    transform: translateX(0);
+  }
+
   .primary-nav {
-    flex-wrap: wrap;
-    justify-content: center;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+    width: 100%;
   }
+
+  .nav-link {
+    font-size: 1.05rem;
+    letter-spacing: 0.08em;
+  }
+
+  .nav-actions {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+  }
+
+  .nav-actions .toggle-theme,
+  .nav-actions .pill-link,
+  .nav-actions .logout-form .pill-link {
+    width: 100%;
+  }
+
   .alert-stack {
     right: 1rem;
     left: 1rem;

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -3,6 +3,58 @@
   const root = document.documentElement;
   const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content');
   const toggleButton = document.querySelector('[data-theme-toggle]');
+  const navContainer = document.querySelector('[data-nav-container]');
+  const navToggle = document.querySelector('[data-nav-toggle]');
+  const navPanel = document.querySelector('[data-nav-panel]');
+  const navBackdrop = document.querySelector('[data-nav-backdrop]');
+
+  const closeMobileNav = ({ returnFocus } = { returnFocus: false }) => {
+    if (!navContainer) return;
+    navContainer.classList.remove('is-nav-open');
+    document.body.classList.remove('nav-open');
+    if (navToggle) {
+      navToggle.setAttribute('aria-expanded', 'false');
+      if (returnFocus) {
+        navToggle.focus();
+      }
+    }
+  };
+
+  if (navToggle && navContainer && navPanel) {
+    navToggle.addEventListener('click', () => {
+      const willOpen = !navContainer.classList.contains('is-nav-open');
+      navContainer.classList.toggle('is-nav-open', willOpen);
+      document.body.classList.toggle('nav-open', willOpen);
+      navToggle.setAttribute('aria-expanded', String(willOpen));
+
+      if (willOpen) {
+        const focusable = navPanel.querySelector(
+          'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        );
+        focusable?.focus();
+      }
+    });
+
+    navBackdrop?.addEventListener('click', () => closeMobileNav({ returnFocus: true }));
+
+    navPanel.querySelectorAll('a[href]').forEach((link) => {
+      link.addEventListener('click', () => closeMobileNav());
+    });
+
+    window.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && navContainer.classList.contains('is-nav-open')) {
+        event.preventDefault();
+        closeMobileNav({ returnFocus: true });
+      }
+    });
+
+    const mq = window.matchMedia('(min-width: 901px)');
+    mq.addEventListener('change', (event) => {
+      if (event.matches) {
+        closeMobileNav();
+      }
+    });
+  }
 
   if (toggleButton && csrfToken) {
     toggleButton.addEventListener('click', async () => {

--- a/views/partials/nav.ejs
+++ b/views/partials/nav.ejs
@@ -1,41 +1,56 @@
 <body class="app-body">
-  <header class="site-header">
+  <header class="site-header" data-nav-container>
     <div class="brand">
       <a href="/" class="brand-link">
         <span class="brand-mark">✦</span>
         <span class="brand-text"><%= hotelName %></span>
       </a>
     </div>
-    <nav class="primary-nav">
-      <a href="/" class="nav-link">Home</a>
-      <a href="/rooms" class="nav-link">Rooms</a>
-      <a href="/amenities" class="nav-link">Amenities</a>
-      <a href="/leadership" class="nav-link">Leadership</a>
-      <a href="/book" class="nav-link">Book</a>
-      <a href="/contact" class="nav-link">Contact</a>
-      <% if (currentUser) { %>
-        <a href="/chat" class="nav-link">Chat</a>
-        <a href="/dashboard" class="nav-link">Dashboard</a>
-        <% if (currentUser.role === 'admin') { %>
-          <a href="/admin" class="nav-link">Admin</a>
+    <button
+      class="nav-toggle"
+      type="button"
+      data-nav-toggle
+      aria-label="Toggle navigation"
+      aria-expanded="false"
+    >
+      <span class="sr-only">Toggle navigation</span>
+      <span class="nav-toggle-bar" aria-hidden="true"></span>
+      <span class="nav-toggle-bar" aria-hidden="true"></span>
+      <span class="nav-toggle-bar" aria-hidden="true"></span>
+    </button>
+    <div class="nav-panel" data-nav-panel>
+      <nav class="primary-nav">
+        <a href="/" class="nav-link">Home</a>
+        <a href="/rooms" class="nav-link">Rooms</a>
+        <a href="/amenities" class="nav-link">Amenities</a>
+        <a href="/leadership" class="nav-link">Leadership</a>
+        <a href="/book" class="nav-link">Book</a>
+        <a href="/contact" class="nav-link">Contact</a>
+        <% if (currentUser) { %>
+          <a href="/chat" class="nav-link">Chat</a>
+          <a href="/dashboard" class="nav-link">Dashboard</a>
+          <% if (currentUser.role === 'admin') { %>
+            <a href="/admin" class="nav-link">Admin</a>
+          <% } %>
         <% } %>
-      <% } %>
-    </nav>
-    <div class="nav-actions">
-      <button class="toggle-theme" data-theme-toggle type="button" aria-label="Toggle theme">
-        <span class="toggle-icon">☀︎</span>
-        <span class="toggle-icon">☾</span>
-      </button>
-      <% if (!currentUser) { %>
-        <a class="pill-link" href="/login">Log in</a>
-        <a class="pill-link primary" href="/signup">Join</a>
-      <% } else { %>
-        <form action="/logout" method="post" class="logout-form">
-          <input type="hidden" name="_csrf" value="<%= csrfToken %>" />
-          <button type="submit" class="pill-link">Log out</button>
-        </form>
-      <% } %>
+      </nav>
+      <div class="nav-actions">
+        <button class="toggle-theme" data-theme-toggle type="button" aria-label="Toggle theme">
+          <span class="toggle-icon">☀︎</span>
+          <span class="toggle-icon">☾</span>
+        </button>
+        <% if (!currentUser) { %>
+          <a class="pill-link" href="/login">Log in</a>
+          <a class="pill-link primary" href="/signup">Join</a>
+        <% } else { %>
+          <form action="/logout" method="post" class="logout-form">
+            <input type="hidden" name="_csrf" value="<%= csrfToken %>" />
+            <button type="submit" class="pill-link">Log out</button>
+          </form>
+        <% } %>
+      </div>
     </div>
   </header>
+  <div class="nav-backdrop" data-nav-backdrop aria-hidden="true"></div>
   <div class="background-sheen" aria-hidden="true"></div>
   <main class="page-content">


### PR DESCRIPTION
## Summary
- refactor the navigation partial to wrap links and actions inside a reusable panel and add a dedicated mobile toggle
- extend the global styles to support an immersive slide-in menu, backdrop, and responsive header sizing on small screens
- add client-side controls to open, close, and focus-manage the mobile navigation panel for accessibility
- prevent the newsletter email field from stretching out of proportion on narrow screens by resetting its flex sizing on mobile

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dddce2aa0c8323a0e805f4d6e497c8