### PR TITLE
Fix contact form validation and log inquiries

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -9,6 +9,8 @@
   --color-surface-alt: rgba(10, 16, 36, 0.86);
   --color-text: #f4f7ff;
   --color-muted: #9aa3c6;
+  --color-danger: #ff6b81;
+  --color-danger-glow: rgba(255, 107, 129, 0.25);
   --shadow-elevated: 0 20px 60px rgba(0, 0, 0, 0.4);
   --gradient-accent: radial-gradient(circle at 20% 20%, rgba(94, 252, 255, 0.4), transparent 55%),
     radial-gradient(circle at 80% 10%, rgba(255, 155, 255, 0.35), transparent 50%),
@@ -22,6 +24,8 @@
   --color-text: #111633;
   --color-muted: #51618f;
   --shadow-elevated: 0 18px 48px rgba(15, 23, 42, 0.18);
+  --color-danger: #d72664;
+  --color-danger-glow: rgba(215, 38, 100, 0.18);
   --gradient-accent: radial-gradient(circle at 10% 10%, rgba(94, 252, 255, 0.4), transparent 60%),
     radial-gradient(circle at 90% 0%, rgba(140, 123, 255, 0.35), transparent 55%),
     linear-gradient(135deg, rgba(252, 254, 255, 0.95), rgba(237, 243, 255, 0.9));
@@ -354,6 +358,18 @@ textarea {
   transition: border 0.2s ease, box-shadow 0.2s ease;
   width: 100%;
   box-sizing: border-box;
+}
+
+.contact-form .input-error {
+  border-color: var(--color-danger);
+  box-shadow: 0 0 0 3px var(--color-danger-glow);
+}
+
+.contact-form .field-error {
+  color: var(--color-danger);
+  font-size: 0.8rem;
+  line-height: 1.3;
+  letter-spacing: 0.02em;
 }
 
 [data-theme='light'] input,

--- a/views/contact.ejs
+++ b/views/contact.ejs
@@ -6,14 +6,64 @@
   <p>Our curators and AI concierge duo are ready to orchestrate your next stay at <%= hotelName %>.</p>
 </section>
 <section class="contact-grid" data-animate="fade-up">
+  <% const nameError = (formErrors && formErrors.name) || null; %>
+  <% const emailError = (formErrors && formErrors.email) || null; %>
+  <% const messageError = (formErrors && formErrors.message) || null; %>
   <form action="/contact" method="post" class="contact-form">
     <input type="hidden" name="_csrf" value="<%= csrfToken %>" />
-    <label for="name">Name</label>
-    <input type="text" id="name" name="name" required />
-    <label for="email">Email</label>
-    <input type="email" id="email" name="email" required />
-    <label for="message">Message</label>
-    <textarea id="message" name="message" rows="5" required></textarea>
+    <div class="field-group">
+      <label for="name">Name</label>
+      <input
+        type="text"
+        id="name"
+        name="name"
+        minlength="2"
+        maxlength="80"
+        autocomplete="name"
+        value="<%= (formValues && formValues.name) || '' %>"
+        class="<%= nameError ? 'input-error' : '' %>"
+        aria-invalid="<%= nameError ? 'true' : 'false' %>"
+        <%= nameError ? 'aria-describedby="name-error"' : '' %>
+        required
+      />
+      <% if (nameError) { %>
+        <p class="field-error" id="name-error"><%= nameError %></p>
+      <% } %>
+    </div>
+    <div class="field-group">
+      <label for="email">Email</label>
+      <input
+        type="email"
+        id="email"
+        name="email"
+        autocomplete="email"
+        value="<%= (formValues && formValues.email) || '' %>"
+        class="<%= emailError ? 'input-error' : '' %>"
+        aria-invalid="<%= emailError ? 'true' : 'false' %>"
+        <%= emailError ? 'aria-describedby="email-error"' : '' %>
+        required
+      />
+      <% if (emailError) { %>
+        <p class="field-error" id="email-error"><%= emailError %></p>
+      <% } %>
+    </div>
+    <div class="field-group">
+      <label for="message">Message</label>
+      <textarea
+        id="message"
+        name="message"
+        rows="5"
+        minlength="10"
+        maxlength="1000"
+        class="<%= messageError ? 'input-error' : '' %>"
+        aria-invalid="<%= messageError ? 'true' : 'false' %>"
+        <%= messageError ? 'aria-describedby="message-error"' : '' %>
+        required
+      ><%= (formValues && formValues.message) || '' %></textarea>
+      <% if (messageError) { %>
+        <p class="field-error" id="message-error"><%= messageError %></p>
+      <% } %>
+    </div>
     <button type="submit" class="cta-button primary">Beam Message</button>
   </form>
   <aside class="contact-info">


### PR DESCRIPTION
## Summary
- persist contact form values and map validation errors to friendly messaging before redirecting
- highlight invalid contact inputs in the UI and align client-side constraints with backend rules
- add an integration test to ensure submissions create guest inquiries and keep websocket notifications working

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dde129290083239c838d1f54d54209