### PR TITLE
Revamp rooms matrix with interactive controls

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -2230,20 +2230,407 @@ tr.is-low .inventory-pill {
   color: var(--color-muted);
 }
 
-.compare-table .table-wrapper {
+.compare-table {
+  margin-top: 4rem;
+  display: grid;
+  gap: 1.6rem;
+}
+
+.compare-table h2 {
+  font-size: clamp(1.9rem, 2.4vw, 2.4rem);
+}
+
+.compare-table .compare-subtitle {
+  max-width: 760px;
+  color: var(--color-muted);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.matrix-controls {
+  display: grid;
+  gap: 1rem;
+  align-items: center;
+}
+
+.matrix-controls .control {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+}
+
+.matrix-controls .control-label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-muted);
+}
+
+.matrix-controls input[type='search'] {
+  min-width: min(360px, 100%);
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(94, 252, 255, 0.25);
+  background: rgba(8, 12, 30, 0.65);
+  color: inherit;
+  box-shadow: inset 0 0 0 1px rgba(94, 252, 255, 0.15);
+}
+
+.matrix-controls input[type='search']::placeholder {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.matrix-controls .pill-link.subtle {
+  padding: 0.35rem 0.9rem;
+  background: rgba(94, 252, 255, 0.12);
+  border-radius: 999px;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  border: 1px solid transparent;
+  transition: transform 0.25s ease, background 0.25s ease, border 0.25s ease;
+}
+
+.matrix-controls .pill-link.subtle:hover,
+.matrix-controls .pill-link.subtle:focus-visible {
+  background: rgba(94, 252, 255, 0.3);
+  border-color: rgba(94, 252, 255, 0.6);
+  transform: translateY(-2px);
+}
+
+.matrix-controls .pill-link.subtle.is-active {
+  background: linear-gradient(135deg, rgba(94, 252, 255, 0.25), rgba(94, 252, 255, 0.5));
+  border-color: rgba(94, 252, 255, 0.8);
+  box-shadow: 0 0 0 1px rgba(94, 252, 255, 0.35);
+}
+
+.matrix-controls .control.toggle {
+  justify-self: flex-start;
+  padding: 0.45rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(94, 252, 255, 0.3);
+  background: transparent;
+  color: inherit;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  transition: background 0.25s ease, color 0.25s ease;
+}
+
+.matrix-controls .control.toggle:hover,
+.matrix-controls .control.toggle:focus-visible {
+  background: rgba(94, 252, 255, 0.2);
+  color: var(--color-bright);
+}
+
+.matrix-controls .control.active-filters {
+  align-items: stretch;
+  gap: 0.6rem;
+}
+
+.filters-empty {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
+  border: 1px solid rgba(94, 252, 255, 0.45);
+  background: rgba(8, 12, 30, 0.6);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  transition: background 0.25s ease, transform 0.25s ease;
+}
+
+.filter-chip:hover,
+.filter-chip:focus-visible {
+  background: rgba(94, 252, 255, 0.25);
+  transform: translateY(-1px);
+}
+
+.matrix-filter-panel {
+  display: grid;
+  gap: 0.8rem;
+  padding: 1rem;
+  border-radius: 18px;
+  border: 1px solid rgba(94, 252, 255, 0.2);
+  background: rgba(5, 10, 28, 0.75);
+  backdrop-filter: blur(12px);
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.matrix-filter-panel label {
+  display: block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: rgba(255, 255, 255, 0.55);
+  margin-bottom: 0.35rem;
+}
+
+.matrix-filter-panel input,
+.matrix-filter-panel select {
+  width: 100%;
+  padding: 0.55rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(94, 252, 255, 0.2);
+  background: rgba(8, 12, 30, 0.8);
+  color: inherit;
+}
+
+.matrix-filter-panel select {
+  appearance: none;
+  background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="%239df5ff"%3E%3Cpath stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m6 9 6 6 6-6"/%3E%3C/svg%3E');
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  background-size: 1rem;
+  padding-right: 2.2rem;
+}
+
+.matrix-filter-panel option {
+  color: #050114;
+}
+
+.table-wrapper.interactive {
+  position: relative;
   overflow-x: auto;
+  border-radius: 24px;
+  border: 1px solid rgba(94, 252, 255, 0.18);
+  background: radial-gradient(circle at center, rgba(94, 252, 255, 0.12), rgba(5, 6, 28, 0.95));
+  padding: 0.4rem;
+  box-shadow: 0 20px 45px rgba(5, 8, 27, 0.55);
+}
+
+.table-wrapper.interactive::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(circle at var(--hover-x, 50%) var(--hover-y, 50%), rgba(94, 252, 255, 0.12), transparent 45%);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.table-wrapper.interactive:hover::before {
+  opacity: 1;
 }
 
 .compare-table table {
   width: 100%;
   border-collapse: collapse;
   font-size: 0.95rem;
+  position: relative;
+  isolation: isolate;
 }
 
-.compare-table th,
-.compare-table td {
-  padding: 0.75rem 0.8rem;
-  border-bottom: 1px solid rgba(94, 252, 255, 0.12);
+.compare-table thead th {
+  position: relative;
+  border-bottom: 1px solid rgba(94, 252, 255, 0.28);
+  padding: 0.9rem 1rem 0.6rem;
+  text-align: left;
+  vertical-align: bottom;
+}
+
+.compare-table thead th button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  padding: 0;
+}
+
+.compare-table thead th button .label {
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.78rem;
+}
+
+.compare-table thead th button .sort-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 50%;
+  background: rgba(94, 252, 255, 0.14);
+  font-size: 0.8rem;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.compare-table thead th button:hover .sort-indicator,
+.compare-table thead th button:focus-visible .sort-indicator {
+  background: rgba(94, 252, 255, 0.35);
+  transform: translateY(-1px);
+}
+
+.compare-table thead th small {
+  display: block;
+  margin-top: 0.3rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.42);
+}
+
+.compare-table tbody td {
+  padding: 0.9rem 1rem;
+  border-bottom: 1px solid rgba(94, 252, 255, 0.08);
+  vertical-align: middle;
+}
+
+.compare-table .matrix-empty td {
+  text-align: center;
+  padding: 2.4rem 1rem;
+}
+
+.matrix-empty-state {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  align-items: center;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.matrix-empty-state span {
+  font-size: 1.6rem;
+  color: var(--color-bright);
+  filter: drop-shadow(0 0 12px rgba(94, 252, 255, 0.4));
+}
+
+.matrix-empty-state p {
+  max-width: 320px;
+  line-height: 1.5;
+}
+
+.compare-table tbody tr {
+  position: relative;
+  transition: background 0.25s ease, transform 0.25s ease;
+}
+
+.compare-table tbody tr:hover,
+.compare-table tbody tr:focus-within {
+  background: rgba(94, 252, 255, 0.08);
+  transform: translateY(-1px);
+}
+
+.compare-table tbody tr::after {
+  content: attr(data-preview);
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.25rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.45);
+  opacity: 0;
+  transform: translateY(6px);
+  transition: opacity 0.25s ease, transform 0.25s ease;
+  pointer-events: none;
+}
+
+.compare-table tbody tr:hover::after,
+.compare-table tbody tr:focus-within::after {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.compare-table .cell-value {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.compare-table .cell-subtext {
+  display: block;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.55);
+  margin-top: 0.25rem;
+  letter-spacing: 0.05em;
+}
+
+.availability-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  background: rgba(94, 252, 255, 0.18);
+}
+
+.availability-pill[data-availability='plenty'] {
+  background: rgba(94, 252, 255, 0.22);
+  color: #041b26;
+}
+
+.availability-pill[data-availability='limited'] {
+  background: rgba(255, 196, 77, 0.25);
+  color: #fbe8c2;
+}
+
+.availability-pill[data-availability='low'] {
+  background: rgba(255, 99, 132, 0.28);
+  color: #ffd8e0;
+}
+
+.compare-table thead th.is-dragging {
+  opacity: 0.6;
+}
+
+.compare-table thead th.is-drop-target::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 3px;
+  background: var(--color-bright);
+  box-shadow: 0 0 12px rgba(94, 252, 255, 0.8);
+}
+
+@media (max-width: 900px) {
+  .matrix-controls {
+    gap: 0.8rem;
+  }
+
+  .matrix-controls .control {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .matrix-controls input[type='search'] {
+    width: 100%;
+  }
+
+  .matrix-controls .control.quick-filters {
+    flex-direction: row;
+  }
+
+  .matrix-filter-panel {
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  }
+
+  .compare-table tbody tr::after {
+    position: static;
+    margin-top: 0.4rem;
+  }
 }
 
 .booking-wizard {

--- a/public/js/rooms.js
+++ b/public/js/rooms.js
@@ -1,0 +1,511 @@
+(() => {
+  const dataElement = document.getElementById('room-matrix-data');
+  const table = document.querySelector('[data-room-matrix-table]');
+  const tableBody = document.querySelector('[data-room-matrix-body]');
+  if (!dataElement || !table || !tableBody) {
+    return;
+  }
+
+  const searchInput = document.querySelector('[data-room-matrix-search]');
+  const quickFilterButtons = Array.from(document.querySelectorAll('[data-quick-filter]'));
+  const filterToggle = document.querySelector('[data-room-matrix-filter-toggle]');
+  const filterPanel = document.querySelector('[data-room-matrix-filter-panel]');
+  const activeFiltersContainer = document.querySelector('[data-room-matrix-active-filters]');
+  const columnFilterInputs = Array.from(document.querySelectorAll('[data-column-filter]'));
+  const wrapper = document.querySelector('[data-room-matrix-wrapper]');
+
+  let rooms = [];
+  try {
+    rooms = JSON.parse(dataElement.textContent.trim());
+  } catch (error) {
+    console.error('Unable to parse room matrix data', error);
+    return;
+  }
+
+  const state = {
+    search: '',
+    columnFilters: {},
+    quickFilters: new Set(),
+    sort: []
+  };
+
+  const quickFilterMeta = {
+    luxury: {
+      label: 'Ultra-luxe',
+      predicate: (room) => room.pricePerNight >= 850 || /villa|pavilion|gallery/i.test(room.name)
+    },
+    wellness: {
+      label: 'Wellness-forward',
+      predicate: (room) =>
+        /spa|wellness|therapy|meditation|pulse|tide|dream/i.test(
+          [room.view, room.vibe, room.features.join(' ')].join(' ')
+        )
+    },
+    solo: {
+      label: 'Solo retreats',
+      predicate: (room) => room.capacity <= 2
+    }
+  };
+
+  const getColumnOrder = () =>
+    Array.from(table.tHead?.rows?.[0]?.cells || []).map((cell) => cell.dataset.key).filter(Boolean);
+
+  const normalise = (value) =>
+    value
+      ? String(value)
+          .toLowerCase()
+          .normalize('NFD')
+          .replace(/\p{Diacritic}/gu, '')
+      : '';
+
+  const nextDirection = (direction) => {
+    if (direction === 'asc') return 'desc';
+    if (direction === 'desc') return null;
+    return 'asc';
+  };
+
+  const applySearch = (room) => {
+    if (!state.search) return true;
+    const haystack = normalise(
+      [room.name, room.view, room.vibe, room.bedConfig, room.features.join(' '), room.addOns.map((addOn) => addOn.name).join(' ')]
+        .join(' ')
+    );
+    return haystack.includes(normalise(state.search));
+  };
+
+  const matchesColumnFilters = (room) => {
+    return Object.entries(state.columnFilters).every(([key, filterValue]) => {
+      if (!filterValue) return true;
+      switch (key) {
+        case 'name':
+          return normalise(room.name).includes(normalise(filterValue));
+        case 'capacity': {
+          if (filterValue === '6+') return room.capacity >= 6;
+          const numeric = Number(filterValue);
+          return Number.isFinite(numeric) ? room.capacity === numeric : true;
+        }
+        case 'squareFeet':
+          if (filterValue === '<700') return room.squareFeet < 700;
+          if (filterValue === '700-1000') return room.squareFeet >= 700 && room.squareFeet <= 1000;
+          if (filterValue === '>1000') return room.squareFeet > 1000;
+          return true;
+        case 'view':
+          return room.view === filterValue;
+        case 'pricePerNight':
+          if (filterValue === '<500') return room.pricePerNight < 500;
+          if (filterValue === '500-800') return room.pricePerNight >= 500 && room.pricePerNight <= 800;
+          if (filterValue === '>800') return room.pricePerNight > 800;
+          return true;
+        default:
+          return true;
+      }
+    });
+  };
+
+  const matchesQuickFilters = (room) => {
+    if (!state.quickFilters.size) return true;
+    for (const key of state.quickFilters) {
+      const filter = quickFilterMeta[key];
+      if (!filter?.predicate(room)) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  const applySort = (dataset) => {
+    if (!state.sort.length) {
+      return dataset.slice();
+    }
+    const collator = new Intl.Collator(undefined, { sensitivity: 'base', numeric: true });
+    return dataset.slice().sort((a, b) => {
+      for (const { key, direction } of state.sort) {
+        let aValue = a[key];
+        let bValue = b[key];
+        if (key === 'pricePerNight' || key === 'capacity' || key === 'squareFeet' || key === 'availability') {
+          aValue = Number(aValue);
+          bValue = Number(bValue);
+        }
+        let comparison = 0;
+        if (typeof aValue === 'number' && typeof bValue === 'number') {
+          comparison = aValue - bValue;
+        } else {
+          comparison = collator.compare(String(aValue ?? ''), String(bValue ?? ''));
+        }
+        if (comparison !== 0) {
+          return direction === 'asc' ? comparison : -comparison;
+        }
+      }
+      return 0;
+    });
+  };
+
+  const formatNumber = (value) => Number(value ?? 0).toLocaleString();
+  const formatCurrency = (value) =>
+    new Intl.NumberFormat(undefined, { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(Number(value));
+
+  const getAvailabilityTone = (availability) => {
+    if (availability >= 8) return 'plenty';
+    if (availability >= 4) return 'limited';
+    return 'low';
+  };
+
+  const renderCell = (key, room) => {
+    switch (key) {
+      case 'name': {
+        const highlight = [room.bedConfig, room.features[0]].filter(Boolean).join(' • ');
+        return `
+          <td data-key="name">
+            <a href="#${room.slug}">${room.name}</a>
+            <span class="cell-subtext">${highlight || 'Signature amenity spotlight'}</span>
+          </td>
+        `;
+      }
+      case 'capacity':
+        return `
+          <td data-key="capacity">
+            <span class="cell-value">${room.capacity}</span>
+            <span class="cell-subtext">guests</span>
+          </td>
+        `;
+      case 'squareFeet':
+        return `
+          <td data-key="squareFeet">
+            <span class="cell-value">${formatNumber(room.squareFeet)}</span>
+            <span class="cell-subtext">sq ft habitat</span>
+          </td>
+        `;
+      case 'view': {
+        const viewHighlight = room.features[1] || room.addOns[0]?.name;
+        return `
+          <td data-key="view">
+            <span class="cell-value">${room.view}</span>
+            <span class="cell-subtext">${viewHighlight || 'Immersive vantage'}</span>
+          </td>
+        `;
+      }
+      case 'pricePerNight':
+        return `
+          <td data-key="pricePerNight">
+            <span class="cell-value">${formatCurrency(room.pricePerNight)}</span>
+            <span class="cell-subtext">per night</span>
+          </td>
+        `;
+      case 'availability': {
+        const tone = getAvailabilityTone(room.availability);
+        return `
+          <td data-key="availability">
+            <span class="availability-pill" data-availability="${tone}">${room.availability} ready</span>
+            <span class="cell-subtext">live inventory</span>
+          </td>
+        `;
+      }
+      default:
+        return `<td data-key="${key}">${room[key]}</td>`;
+    }
+  };
+
+  const renderTableBody = () => {
+    const order = getColumnOrder();
+    const filtered = rooms.filter((room) => applySearch(room) && matchesColumnFilters(room) && matchesQuickFilters(room));
+    const sorted = applySort(filtered);
+    if (!sorted.length) {
+      tableBody.innerHTML = `
+        <tr class="matrix-empty">
+          <td colspan="${order.length}">
+            <div class="matrix-empty-state">
+              <span aria-hidden="true">✦</span>
+              <p>No habitats match your filters yet. Try adjusting the matrix.</p>
+            </div>
+          </td>
+        </tr>
+      `;
+      updateSortIndicators();
+      updateActiveFilters();
+      return;
+    }
+    const rows = sorted
+      .map((room) => {
+        const cells = order.map((key) => renderCell(key, room)).join('');
+        return `<tr data-room="${room.slug}">${cells}</tr>`;
+      })
+      .join('');
+    tableBody.innerHTML = rows;
+    sorted.forEach((room) => {
+      const row = tableBody.querySelector(`tr[data-room="${room.slug}"]`);
+      if (row) {
+        row.dataset.preview = [room.bedConfig, room.features[0], room.addOns[0]?.name]
+          .filter(Boolean)
+          .join(' • ');
+      }
+    });
+    updateSortIndicators();
+    updateActiveFilters();
+  };
+
+  const updateSortIndicators = () => {
+    const headers = Array.from(table.tHead?.rows?.[0]?.cells || []);
+    headers.forEach((header) => {
+      const key = header.dataset.key;
+      const indicator = header.querySelector('.sort-indicator');
+      const orderLabel = header.querySelector('[data-sort-order]');
+      header.removeAttribute('aria-sort');
+      if (!indicator) return;
+      const sortIndex = state.sort.findIndex((item) => item.key === key);
+      if (sortIndex === -1) {
+        indicator.textContent = '↕';
+        indicator.dataset.direction = '';
+        indicator.dataset.position = '';
+        if (orderLabel) {
+          orderLabel.textContent = 'Not sorted';
+        }
+        return;
+      }
+      const { direction } = state.sort[sortIndex];
+      const arrow = direction === 'asc' ? '↑' : '↓';
+      indicator.textContent = `${arrow}${sortIndex + 1}`;
+      indicator.dataset.direction = direction;
+      indicator.dataset.position = String(sortIndex + 1);
+      if (orderLabel) {
+        orderLabel.textContent = `Sorted ${direction === 'asc' ? 'ascending' : 'descending'} priority ${sortIndex + 1}`;
+      }
+      header.setAttribute('aria-sort', direction === 'asc' ? 'ascending' : 'descending');
+    });
+  };
+
+  const describeFilterValue = (key, value) => {
+    switch (key) {
+      case 'name':
+        return `Name contains “${value}”`;
+      case 'capacity':
+        return value === '6+' ? 'Capacity 6+' : `Capacity ${value}`;
+      case 'squareFeet':
+        if (value === '<700') return 'Under 700 sq ft';
+        if (value === '700-1000') return '700-1000 sq ft';
+        if (value === '>1000') return 'Over 1000 sq ft';
+        return value;
+      case 'view':
+        return `View: ${value}`;
+      case 'pricePerNight':
+        if (value === '<500') return 'Under $500';
+        if (value === '500-800') return '$500-$800';
+        if (value === '>800') return 'Over $800';
+        return value;
+      default:
+        return value;
+    }
+  };
+
+  const updateActiveFilters = () => {
+    if (!activeFiltersContainer) return;
+    const chips = [];
+    if (state.search) {
+      chips.push({ type: 'search', key: 'search', label: `Search: “${state.search}”` });
+    }
+    Object.entries(state.columnFilters).forEach(([key, value]) => {
+      if (!value) return;
+      chips.push({ type: 'column', key, label: describeFilterValue(key, value) });
+    });
+    state.quickFilters.forEach((key) => {
+      const meta = quickFilterMeta[key];
+      if (meta) {
+        chips.push({ type: 'quick', key, label: meta.label });
+      }
+    });
+
+    if (!chips.length) {
+      activeFiltersContainer.innerHTML = '<span class="filters-empty">No filters active</span>';
+      return;
+    }
+
+    activeFiltersContainer.innerHTML = chips
+      .map(
+        (chip) =>
+          `<button type="button" class="filter-chip" data-remove-type="${chip.type}" data-remove-key="${chip.key}">
+            ${chip.label}<span aria-hidden="true"> ×</span>
+          </button>`
+      )
+      .join('');
+  };
+
+  const cycleSort = (key, multi) => {
+    const existingIndex = state.sort.findIndex((item) => item.key === key);
+    const currentDirection = existingIndex === -1 ? null : state.sort[existingIndex].direction;
+    const next = nextDirection(currentDirection);
+    if (!multi) {
+      state.sort = [];
+      if (next) {
+        state.sort.push({ key, direction: next });
+      }
+      return;
+    }
+    if (existingIndex === -1) {
+      if (next) {
+        state.sort.push({ key, direction: next });
+      }
+      return;
+    }
+    if (!next) {
+      state.sort.splice(existingIndex, 1);
+    } else {
+      state.sort[existingIndex].direction = next;
+    }
+  };
+
+  const handleSortClick = (event) => {
+    const trigger = event.target.closest('[data-sort-trigger]');
+    if (!trigger) return;
+    const header = trigger.closest('th');
+    const key = header?.dataset.key;
+    if (!key) return;
+    const multi = event.shiftKey;
+    cycleSort(key, multi);
+    renderTableBody();
+  };
+
+  const handleSearchInput = (event) => {
+    state.search = event.target.value.trim();
+    renderTableBody();
+  };
+
+  const handleColumnFilterChange = (event) => {
+    const key = event.target.dataset.columnFilter;
+    if (!key) return;
+    const value = event.target.tagName === 'INPUT' ? event.target.value.trim() : event.target.value;
+    if (!value) {
+      delete state.columnFilters[key];
+    } else {
+      state.columnFilters[key] = value;
+    }
+    renderTableBody();
+  };
+
+  const handleQuickFilterToggle = (event) => {
+    const button = event.currentTarget;
+    const key = button.dataset.quickFilter;
+    if (!key) return;
+    const isActive = state.quickFilters.has(key);
+    if (isActive) {
+      state.quickFilters.delete(key);
+    } else {
+      state.quickFilters.add(key);
+    }
+    button.classList.toggle('is-active', !isActive);
+    button.setAttribute('aria-pressed', String(!isActive));
+    renderTableBody();
+  };
+
+  const handleActiveFilterClick = (event) => {
+    const button = event.target.closest('[data-remove-type]');
+    if (!button) return;
+    const { removeType, removeKey } = button.dataset;
+    if (removeType === 'search') {
+      state.search = '';
+      if (searchInput) {
+        searchInput.value = '';
+      }
+    } else if (removeType === 'column') {
+      delete state.columnFilters[removeKey];
+      const input = columnFilterInputs.find((element) => element.dataset.columnFilter === removeKey);
+      if (input) {
+        input.value = '';
+      }
+    } else if (removeType === 'quick') {
+      state.quickFilters.delete(removeKey);
+      const buttonToReset = quickFilterButtons.find((element) => element.dataset.quickFilter === removeKey);
+      if (buttonToReset) {
+        buttonToReset.classList.remove('is-active');
+        buttonToReset.setAttribute('aria-pressed', 'false');
+      }
+    }
+    renderTableBody();
+  };
+
+  const toggleFilterPanel = () => {
+    if (!filterToggle || !filterPanel) return;
+    const expanded = filterToggle.getAttribute('aria-expanded') === 'true';
+    filterToggle.setAttribute('aria-expanded', String(!expanded));
+    filterPanel.hidden = expanded;
+    if (!expanded) {
+      filterPanel.querySelector('[data-column-filter]')?.focus({ preventScroll: true });
+    }
+  };
+
+  const attachColumnDragHandlers = () => {
+    const headerCells = Array.from(table.tHead?.rows?.[0]?.cells || []);
+    let dragged = null;
+
+    headerCells.forEach((cell) => {
+      cell.addEventListener('dragstart', (event) => {
+        dragged = cell;
+        cell.classList.add('is-dragging');
+        event.dataTransfer.effectAllowed = 'move';
+        event.dataTransfer.setData('text/plain', cell.dataset.key || '');
+      });
+
+      cell.addEventListener('dragend', () => {
+        cell.classList.remove('is-dragging');
+        dragged = null;
+      });
+
+      cell.addEventListener('dragover', (event) => {
+        if (!dragged || dragged === cell) return;
+        event.preventDefault();
+        cell.classList.add('is-drop-target');
+      });
+
+      cell.addEventListener('dragleave', () => {
+        cell.classList.remove('is-drop-target');
+      });
+
+      cell.addEventListener('drop', (event) => {
+        if (!dragged || dragged === cell) return;
+        event.preventDefault();
+        cell.classList.remove('is-drop-target');
+        const headerRow = cell.parentElement;
+        if (!headerRow) return;
+        const children = Array.from(headerRow.children);
+        const draggedIndex = children.indexOf(dragged);
+        const targetIndex = children.indexOf(cell);
+        if (draggedIndex < targetIndex) {
+          headerRow.insertBefore(dragged, cell.nextSibling);
+        } else {
+          headerRow.insertBefore(dragged, cell);
+        }
+        renderTableBody();
+      });
+    });
+  };
+
+  const setupHoverEffects = () => {
+    if (!wrapper) return;
+    wrapper.addEventListener('pointermove', (event) => {
+      const row = event.target.closest('tbody tr');
+      if (!row) return;
+      wrapper.style.setProperty('--hover-x', `${event.clientX}px`);
+      wrapper.style.setProperty('--hover-y', `${event.clientY}px`);
+    });
+    wrapper.addEventListener('pointerleave', () => {
+      wrapper.style.removeProperty('--hover-x');
+      wrapper.style.removeProperty('--hover-y');
+    });
+  };
+
+  table.addEventListener('click', handleSortClick);
+  searchInput?.addEventListener('input', handleSearchInput);
+  quickFilterButtons.forEach((button) => {
+    button.setAttribute('aria-pressed', 'false');
+    button.addEventListener('click', handleQuickFilterToggle);
+  });
+  columnFilterInputs.forEach((input) => {
+    state.columnFilters[input.dataset.columnFilter] = '';
+    const eventName = input.tagName === 'INPUT' ? 'input' : 'change';
+    input.addEventListener(eventName, handleColumnFilterChange);
+  });
+  activeFiltersContainer?.addEventListener('click', handleActiveFilterClick);
+  filterToggle?.addEventListener('click', toggleFilterPanel);
+
+  attachColumnDragHandlers();
+  setupHoverEffects();
+  renderTableBody();
+})();

--- a/scripts/seed.js
+++ b/scripts/seed.js
@@ -283,6 +283,90 @@ function insertRoomTypes() {
         { id: 'soundbath', name: 'Sound bath immersion', price: 55 }
       ],
       availability: 10
+    },
+    {
+      name: 'Luminous Tidal Pavilion',
+      slug: 'luminous-tidal-pavilion',
+      pricePerNight: 980,
+      capacity: 5,
+      squareFeet: 1500,
+      bedConfig: '2 Tidal Queens + 1 Halo Nest',
+      view: 'Bioluminescent tide garden',
+      description: 'Floating pavilion with kinetic tide pools choreographed to lunar rhythms.',
+      features: [
+        'Kinetic tide pool deck',
+        'Ocean-resonance sound chamber',
+        'Private moonbeam tasting bar'
+      ],
+      images: ['/images/suite.svg', '/images/skyline.svg'],
+      addOns: [
+        { id: 'tidal-tasting', name: 'Moonbeam tasting flight', price: 180 },
+        { id: 'tide-concierge', name: 'Tide concierge for night rituals', price: 140 }
+      ],
+      availability: 4
+    },
+    {
+      name: 'Zenith Observatory Pod',
+      slug: 'zenith-observatory-pod',
+      pricePerNight: 560,
+      capacity: 2,
+      squareFeet: 720,
+      bedConfig: '1 Horizon King',
+      view: '360° starfield dome',
+      description: 'Observation pod with adaptive telescope canopy and meteor shower alarms.',
+      features: [
+        'Celestial projection dome',
+        'Autonomous star-mapping assistant',
+        'Aurora tea ritual bench'
+      ],
+      images: ['/images/nebula.svg', '/images/skyline.svg'],
+      addOns: [
+        { id: 'meteor-alert', name: 'Personal meteor alert service', price: 65 },
+        { id: 'stargazer', name: 'Guided midnight constellation walk', price: 95 }
+      ],
+      availability: 9
+    },
+    {
+      name: 'Chrono Dream Capsule',
+      slug: 'chrono-dream-capsule',
+      pricePerNight: 360,
+      capacity: 1,
+      squareFeet: 420,
+      bedConfig: '1 Chrono Cocoon',
+      view: 'Temporal meditation atrium',
+      description: 'Solo capsule designed for chrono-therapy sleep with lucid dream sequencing.',
+      features: [
+        'Chrono sleep sequencer',
+        'Lucid dream guidance AI',
+        'Aroma memory diffuser'
+      ],
+      images: ['/images/nebula.svg'],
+      addOns: [
+        { id: 'chrono-coach', name: 'Chrono sleep coach session', price: 70 },
+        { id: 'memory-journal', name: 'Dream memory journal kit', price: 35 }
+      ],
+      availability: 12
+    },
+    {
+      name: 'Solar Flare Gallery Suite',
+      slug: 'solar-flare-gallery-suite',
+      pricePerNight: 740,
+      capacity: 3,
+      squareFeet: 1100,
+      bedConfig: '1 Radiant King + 1 Lumen Lounger',
+      view: 'Solar flare art promenade',
+      description: 'Immersive art gallery suite where kinetic sculptures respond to solar activity.',
+      features: [
+        'Solar flare kinetic gallery',
+        'Private scent-wave atelier',
+        'AI-curated vinyl lounge'
+      ],
+      images: ['/images/suite.svg', '/images/nebula.svg'],
+      addOns: [
+        { id: 'gallery-tour', name: 'Curated art immersion tour', price: 160 },
+        { id: 'vinyl-session', name: 'Analog vinyl soundscape session', price: 90 }
+      ],
+      availability: 6
     }
   ];
 

--- a/views/rooms.ejs
+++ b/views/rooms.ejs
@@ -86,31 +86,164 @@
 </section>
 
 <section class="compare-table" data-animate="fade-up">
-  <h2>Compare at a glance</h2>
-  <div class="table-wrapper">
-    <table>
+  <h2>Galactic accommodation matrix</h2>
+  <p class="compare-subtitle">
+    Search, sort, and remix our celestial inventory. Drag column headings to reorder, shift-click to build layered sorts,
+    and use filters to surface the exact habitat for your orbit.
+  </p>
+  <div class="matrix-controls" data-room-matrix-controls>
+    <label class="control search" for="room-matrix-search">
+      <span class="control-label">Search the constellation</span>
+      <input
+        id="room-matrix-search"
+        type="search"
+        placeholder="Search by room, vibe, feature, or view"
+        autocomplete="off"
+        data-room-matrix-search
+      />
+    </label>
+    <div class="control quick-filters" role="group" aria-label="Quick filters">
+      <button type="button" data-quick-filter="luxury" class="pill-link subtle">Ultra-luxe</button>
+      <button type="button" data-quick-filter="wellness" class="pill-link subtle">Wellness-forward</button>
+      <button type="button" data-quick-filter="solo" class="pill-link subtle">Solo retreats</button>
+    </div>
+    <div class="control active-filters" data-room-matrix-active-filters aria-live="polite"></div>
+    <button class="control toggle" type="button" data-room-matrix-filter-toggle aria-expanded="false">
+      Column filters
+    </button>
+  </div>
+  <div class="matrix-filter-panel" data-room-matrix-filter-panel hidden>
+    <div class="filter" data-filter-key="name">
+      <label for="filter-name">Room</label>
+      <input id="filter-name" type="text" placeholder="Type a room name" data-column-filter="name" />
+    </div>
+    <div class="filter" data-filter-key="capacity">
+      <label for="filter-capacity">Capacity</label>
+      <select id="filter-capacity" data-column-filter="capacity">
+        <option value="">Any</option>
+        <option value="1">Solo traveller</option>
+        <option value="2">2 guests</option>
+        <option value="3">3 guests</option>
+        <option value="4">4 guests</option>
+        <option value="5">5 guests</option>
+        <option value="6+">6 or more</option>
+      </select>
+    </div>
+    <div class="filter" data-filter-key="squareFeet">
+      <label for="filter-space">Space</label>
+      <select id="filter-space" data-column-filter="squareFeet">
+        <option value="">Any</option>
+        <option value="<700">Under 700 sq ft</option>
+        <option value="700-1000">700 - 1000 sq ft</option>
+        <option value=">1000">Over 1000 sq ft</option>
+      </select>
+    </div>
+    <div class="filter" data-filter-key="view">
+      <label for="filter-view">View</label>
+      <select id="filter-view" data-column-filter="view">
+        <option value="">Any</option>
+        <% Array.from(new Set(rooms.map(room => room.view))).forEach(function(view) { %>
+          <option value="<%= view %>"><%= view %></option>
+        <% }) %>
+      </select>
+    </div>
+    <div class="filter" data-filter-key="pricePerNight">
+      <label for="filter-price">Nightly rate</label>
+      <select id="filter-price" data-column-filter="pricePerNight">
+        <option value="">Any</option>
+        <option value="<500">Under $500</option>
+        <option value="500-800">$500 - $800</option>
+        <option value=">800">Over $800</option>
+      </select>
+    </div>
+  </div>
+  <div class="table-wrapper interactive" data-room-matrix-wrapper>
+    <table data-room-matrix-table>
       <thead>
         <tr>
-          <th>Room</th>
-          <th>Capacity</th>
-          <th>Space</th>
-          <th>View</th>
-          <th>From (night)</th>
+          <th scope="col" data-key="name" draggable="true">
+            <button type="button" data-sort-trigger>
+              <span class="label">Name</span>
+              <span class="sort-indicator" aria-hidden="true">↕</span>
+              <span class="sort-order sr-only" data-sort-order></span>
+            </button>
+            <small>Drag to reorder</small>
+          </th>
+          <th scope="col" data-key="capacity" draggable="true">
+            <button type="button" data-sort-trigger>
+              <span class="label">Capacity</span>
+              <span class="sort-indicator" aria-hidden="true">↕</span>
+              <span class="sort-order sr-only" data-sort-order></span>
+            </button>
+            <small>Guests</small>
+          </th>
+          <th scope="col" data-key="squareFeet" draggable="true">
+            <button type="button" data-sort-trigger>
+              <span class="label">Space</span>
+              <span class="sort-indicator" aria-hidden="true">↕</span>
+              <span class="sort-order sr-only" data-sort-order></span>
+            </button>
+            <small>sq ft</small>
+          </th>
+          <th scope="col" data-key="view" draggable="true">
+            <button type="button" data-sort-trigger>
+              <span class="label">View</span>
+              <span class="sort-indicator" aria-hidden="true">↕</span>
+              <span class="sort-order sr-only" data-sort-order></span>
+            </button>
+            <small>Atmosphere</small>
+          </th>
+          <th scope="col" data-key="pricePerNight" draggable="true">
+            <button type="button" data-sort-trigger>
+              <span class="label">From (night)</span>
+              <span class="sort-indicator" aria-hidden="true">↕</span>
+              <span class="sort-order sr-only" data-sort-order></span>
+            </button>
+            <small>USD</small>
+          </th>
+          <th scope="col" data-key="availability" draggable="true">
+            <button type="button" data-sort-trigger>
+              <span class="label">Availability</span>
+              <span class="sort-indicator" aria-hidden="true">↕</span>
+              <span class="sort-order sr-only" data-sort-order></span>
+            </button>
+            <small>Suites</small>
+          </th>
         </tr>
       </thead>
-      <tbody>
+      <tbody data-room-matrix-body>
         <% rooms.forEach(function(room) { %>
           <tr>
-            <td><a href="#<%= room.slug %>"><%= room.name %></a></td>
-            <td><%= room.capacity %></td>
-            <td><%= room.squareFeet %> sq ft</td>
-            <td><%= room.view %></td>
-            <td>$<%= room.pricePerNight %></td>
+            <td data-key="name"><a href="#<%= room.slug %>"><%= room.name %></a></td>
+            <td data-key="capacity"><%= room.capacity %></td>
+            <td data-key="squareFeet"><%= room.squareFeet %> sq ft</td>
+            <td data-key="view"><%= room.view %></td>
+            <td data-key="pricePerNight">$<%= room.pricePerNight %></td>
+            <td data-key="availability"><%= room.availability %> ready</td>
           </tr>
         <% }) %>
       </tbody>
     </table>
   </div>
 </section>
+
+<script type="application/json" id="room-matrix-data">
+  <%- JSON.stringify(rooms.map(function(room) {
+    return {
+      name: room.name,
+      slug: room.slug,
+      capacity: room.capacity,
+      squareFeet: room.squareFeet,
+      view: room.view,
+      pricePerNight: room.pricePerNight,
+      availability: room.availability,
+      bedConfig: room.bedConfig,
+      features: room.features,
+      addOns: room.addOns,
+      vibe: room.description
+    };
+  })) %>
+</script>
+<script defer src="/js/rooms.js"></script>
 
 <%- include('partials/footer') %>


### PR DESCRIPTION
## Summary
- redesign the Rooms comparison matrix with searchable, filterable, and reorderable columns plus quick filter controls
- add dedicated client-side script and styling for hover previews, multi-sort indicators, and empty-state messaging
- expand seeded room inventory with new suites, pods, and add-on experiences

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ec62019cf48323a9ec6d4e3f884c4c