### PR TITLE
Configure trust proxy for rate limiter

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -19,6 +19,10 @@ const adminRoutes = require('./routes/admin');
 
 const app = express();
 
+// Ensure Express respects proxy headers so rate limiting can accurately
+// identify clients when the app is behind a reverse proxy.
+app.set('trust proxy', true);
+
 app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, '..', 'views'));
 


### PR DESCRIPTION
## Summary
- enable Express trust proxy so rate limiting can correctly identify clients when behind a proxy
- prevent express-rate-limit validation errors triggered by forwarded headers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ec6b3408fc8323a72fc126cd450f2b