### PR TITLE
feat: add dining prisma schema and api skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+DATABASE_URL="postgresql://USER:PASSWORD@HOST:PORT/DATABASE?schema=public"
+HOTEL_JWT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\n...replace_with_real_key...\n-----END PUBLIC KEY-----\n"
+DINING_PORT=4000

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@prisma/client": "^6.17.1",
         "bcrypt": "^5.1.1",
         "better-sqlite3": "^9.4.0",
         "connect-sqlite3": "^0.9.15",
+        "cookie": "^0.6.0",
         "csurf": "^1.11.0",
         "ejs": "^3.1.9",
         "express": "^5.1.0",
@@ -19,15 +21,26 @@
         "express-session": "^1.18.1",
         "express-validator": "^7.0.1",
         "helmet": "^7.0.0",
+        "ioredis": "^5.4.1",
         "joi": "^17.12.0",
+        "jsonwebtoken": "^9.0.2",
+        "pg": "^8.11.5",
+        "pg-hstore": "^2.3.4",
         "sanitize-html": "^2.13.0",
+        "sequelize": "^6.37.3",
         "socket.io": "^4.7.5",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
+        "@types/cookie": "^0.6.0",
+        "@types/express": "^5.0.3",
+        "@types/node": "^24.7.2",
         "jest": "^29.7.0",
         "nodemon": "^3.1.0",
-        "supertest": "^6.3.4"
+        "prisma": "^6.17.1",
+        "supertest": "^6.3.4",
+        "tsx": "^4.20.6",
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -546,6 +559,448 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
@@ -567,6 +1022,12 @@
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.4.0.tgz",
+      "integrity": "sha512-aFT2yemJJo+TZCmieA7qnYGQooOS7QfNmYrzGtsYd3g9j5iDP8AimYYAesf79ohjbLG12XxC4nG5DyEnC88AsQ==",
+      "license": "MIT"
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -1006,6 +1467,91 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "node_modules/@prisma/client": {
+      "version": "6.17.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.17.1.tgz",
+      "integrity": "sha512-zL58jbLzYamjnNnmNA51IOZdbk5ci03KviXCuB0Tydc9btH2kDWsi1pQm2VecviRTM7jGia0OPPkgpGnT3nKvw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "prisma": "*",
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/config": {
+      "version": "6.17.1",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.17.1.tgz",
+      "integrity": "sha512-fs8wY6DsvOCzuiyWVckrVs1LOcbY4LZNz8ki4uUIQ28jCCzojTGqdLhN2Jl5lDnC1yI8/gNIKpsWDM8pLhOdwA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "c12": "3.1.0",
+        "deepmerge-ts": "7.1.5",
+        "effect": "3.16.12",
+        "empathic": "2.0.0"
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "6.17.1",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.17.1.tgz",
+      "integrity": "sha512-Vf7Tt5Wh9XcndpbmeotuqOMLWPTjEKCsgojxXP2oxE1/xYe7PtnP76hsouG9vis6fctX+TxgmwxTuYi/+xc7dQ==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines": {
+      "version": "6.17.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.17.1.tgz",
+      "integrity": "sha512-D95Ik3GYZkqZ8lSR4EyFOJ/tR33FcYRP8kK61o+WMsyD10UfJwd7+YielflHfKwiGodcqKqoraWw8ElAgMDbPw==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.17.1",
+        "@prisma/engines-version": "6.17.1-1.272a37d34178c2894197e17273bf937f25acdeac",
+        "@prisma/fetch-engine": "6.17.1",
+        "@prisma/get-platform": "6.17.1"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "6.17.1-1.272a37d34178c2894197e17273bf937f25acdeac",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.17.1-1.272a37d34178c2894197e17273bf937f25acdeac.tgz",
+      "integrity": "sha512-17140E3huOuD9lMdJ9+SF/juOf3WR3sTJMVyyenzqUPbuH+89nPhSWcrY+Mf7tmSs6HvaO+7S+HkELinn6bhdg==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "6.17.1",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.17.1.tgz",
+      "integrity": "sha512-AYZiHOs184qkDMiTeshyJCtyL4yERkjfTkJiSJdYuSfc24m94lTNL5+GFinZ6vVz+ktX4NJzHKn1zIFzGTWrWg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.17.1",
+        "@prisma/engines-version": "6.17.1-1.272a37d34178c2894197e17273bf937f25acdeac",
+        "@prisma/get-platform": "6.17.1"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "6.17.1",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.17.1.tgz",
+      "integrity": "sha512-AKEn6fsfz0r482S5KRDFlIGEaq9wLNcgalD1adL+fPcFFblIKs1sD81kY/utrHdqKuVC6E1XSRpegDK3ZLL4Qg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.17.1"
+      }
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
@@ -1058,6 +1604,13 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tootallnate/once": {
@@ -1115,6 +1668,34 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/cors": {
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
@@ -1122,6 +1703,40 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.3.tgz",
+      "integrity": "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.0.tgz",
+      "integrity": "sha512-jnHMsrd0Mwa9Cf4IdOzbz543y4XJepXrbia2T4b6+spXC2We3t1y6K44D3mR8XMFSXMCf3/l7rCgddfx7UNVBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
       }
     },
     "node_modules/@types/graceful-fs": {
@@ -1133,6 +1748,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -1161,13 +1783,73 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
-      "version": "24.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
-      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
+      "version": "24.7.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.2.tgz",
+      "integrity": "sha512-/NbVmcGTP+lj5oa4yiYxxeBjRivKQ5Ns1eSZeB99ExsEQ6rX5XYU1Zy/gGxY/ilqtD4Etx9mKyrPxZRetiahhA==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.12.0"
+        "undici-types": "~7.14.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-zBF6vZJn1IaMpg3xUF25VK3gd3l8zwE0ZLRX7dsQyQi+jp4E8mMDJNGDYnYse+bQhYwWERTxVwHpi3dMOq7RKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.9.tgz",
+      "integrity": "sha512-dOTIuqpWLyl3BBXU3maNQsS4A3zuuoYRNIvYSxxhebPfXg2mzWQEPne/nlJ37yOse6uGgR386uTpdsx4D0QZWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
+      "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -1175,6 +1857,12 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/validator": {
+      "version": "13.15.3",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.3.tgz",
+      "integrity": "sha512-7bcUmDyS6PN3EuD9SlGGOxM77F8WLVsrwkxyWxKnxzmXoequ6c7741QBrANq6htVRGOITJ7z72mTP6Z4XyuG+Q==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -1696,6 +2384,12 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -1710,6 +2404,65 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/c12": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
+      "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^4.0.3",
+        "confbox": "^0.2.2",
+        "defu": "^6.1.4",
+        "dotenv": "^16.6.1",
+        "exsolve": "^1.0.7",
+        "giget": "^2.0.0",
+        "jiti": "^2.4.2",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "perfect-debounce": "^1.0.0",
+        "pkg-types": "^2.2.0",
+        "rc9": "^2.1.2"
+      },
+      "peerDependencies": {
+        "magicast": "^0.3.5"
+      },
+      "peerDependenciesMeta": {
+        "magicast": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/c12/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/c12/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/cacache": {
@@ -1938,6 +2691,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/citty": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "consola": "^3.2.3"
+      }
+    },
     "node_modules/cjs-module-lexer": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
@@ -1968,6 +2731,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/co": {
@@ -2046,6 +2818,13 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
     },
+    "node_modules/confbox": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
+      "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/connect-sqlite3": {
       "version": "0.9.16",
       "resolved": "https://registry.npmjs.org/connect-sqlite3/-/connect-sqlite3-0.9.16.tgz",
@@ -2055,6 +2834,16 @@
       },
       "engines": {
         "node": ">=0.4.x"
+      }
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
       }
     },
     "node_modules/console-control-strings": {
@@ -2092,9 +2881,9 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2325,6 +3114,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/deepmerge-ts": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
+      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -2341,6 +3147,15 @@
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
       "license": "MIT"
     },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -2349,6 +3164,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.1",
@@ -2445,6 +3267,25 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "devOptional": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dottie": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.6.tgz",
+      "integrity": "sha512-iGCHkfUc5kFekGiqhe8B/mdaurD+lakO9txNnTvKtA6PISrw86LgqHvRzWYPyoE2Ph5aMIrCw9/uko6XHTKCwA==",
+      "license": "MIT"
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -2459,11 +3300,31 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
+    },
+    "node_modules/effect": {
+      "version": "3.16.12",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.16.12.tgz",
+      "integrity": "sha512-N39iBk0K71F9nb442TLbTkjl24FLUzuvx2i1I2RsEAQsdAdUTuUoW0vlfUXgkMTUOnYqKnWcFfqw4hK4Pw27hg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "fast-check": "^3.23.1"
+      }
     },
     "node_modules/ejs": {
       "version": "3.1.10",
@@ -2505,6 +3366,16 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
+    },
+    "node_modules/empathic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
+      "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -2572,6 +3443,15 @@
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
       },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -2706,6 +3586,48 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.10",
+        "@esbuild/android-arm": "0.25.10",
+        "@esbuild/android-arm64": "0.25.10",
+        "@esbuild/android-x64": "0.25.10",
+        "@esbuild/darwin-arm64": "0.25.10",
+        "@esbuild/darwin-x64": "0.25.10",
+        "@esbuild/freebsd-arm64": "0.25.10",
+        "@esbuild/freebsd-x64": "0.25.10",
+        "@esbuild/linux-arm": "0.25.10",
+        "@esbuild/linux-arm64": "0.25.10",
+        "@esbuild/linux-ia32": "0.25.10",
+        "@esbuild/linux-loong64": "0.25.10",
+        "@esbuild/linux-mips64el": "0.25.10",
+        "@esbuild/linux-ppc64": "0.25.10",
+        "@esbuild/linux-riscv64": "0.25.10",
+        "@esbuild/linux-s390x": "0.25.10",
+        "@esbuild/linux-x64": "0.25.10",
+        "@esbuild/netbsd-arm64": "0.25.10",
+        "@esbuild/netbsd-x64": "0.25.10",
+        "@esbuild/openbsd-arm64": "0.25.10",
+        "@esbuild/openbsd-x64": "0.25.10",
+        "@esbuild/openharmony-arm64": "0.25.10",
+        "@esbuild/sunos-x64": "0.25.10",
+        "@esbuild/win32-arm64": "0.25.10",
+        "@esbuild/win32-ia32": "0.25.10",
+        "@esbuild/win32-x64": "0.25.10"
       }
     },
     "node_modules/escalade": {
@@ -2894,6 +3816,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/express-session/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/express-session/node_modules/cookie-signature": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
@@ -2926,6 +3857,45 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/exsolve": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
+      "integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/fast-json-stable-stringify": {
@@ -3244,6 +4214,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.12.0.tgz",
+      "integrity": "sha512-LScr2aNr2FbjAjZh2C6X6BxRx1/x+aTDExct/xyq2XKbYOiG5c0aK7pMsSuyc0brz3ibr/lbQiHD9jzt4lccJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/giget": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
+      "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "citty": "^0.1.6",
+        "consola": "^3.4.0",
+        "defu": "^6.1.4",
+        "node-fetch-native": "^1.6.6",
+        "nypm": "^0.6.0",
+        "pathe": "^2.0.3"
+      },
+      "bin": {
+        "giget": "dist/cli.mjs"
       }
     },
     "node_modules/github-from-package": {
@@ -3584,6 +4585,15 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/inflection": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.13.4.tgz",
+      "integrity": "sha512-6I/HUDeYFfuNCVS3td055BaXBwKYuzw7K3ExVMStBowKo9oOAMJIXIHvdyR3iboTCp1b+1i5DSkIZTcwIktuDw==",
+      "engines": [
+        "node >= 0.4.0"
+      ],
+      "license": "MIT"
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -3606,6 +4616,30 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
+    },
+    "node_modules/ioredis": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.8.1.tgz",
+      "integrity": "sha512-Qho8TgIamqEPdgiMadJwzRMW3TudIg6vpg4YONokGDudy4eqRIJtDbVX72pfLBcWxvbn3qm/40TyGUObdW4tLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.4.0",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
     },
     "node_modules/ip-address": {
       "version": "10.0.1",
@@ -4476,6 +5510,16 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/joi": {
       "version": "17.13.3",
       "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
@@ -4543,6 +5587,49 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -4587,6 +5674,60 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -5029,6 +6170,27 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.48",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
+      "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -5112,6 +6274,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/node-gyp": {
       "version": "8.4.1",
@@ -5309,6 +6478,26 @@
         "set-blocking": "^2.0.0"
       }
     },
+    "node_modules/nypm": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.2.tgz",
+      "integrity": "sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "citty": "^0.1.6",
+        "consola": "^3.4.2",
+        "pathe": "^2.0.3",
+        "pkg-types": "^2.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "bin": {
+        "nypm": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": "^14.16.0 || >=16.10.0"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -5329,6 +6518,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -5527,6 +6723,121 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-hstore": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/pg-hstore/-/pg-hstore-2.3.4.tgz",
+      "integrity": "sha512-N3SGs/Rf+xA1M2/n0JBiXFDVMzdekwLZLAO0g7mpDY9ouX+fDI7jS6kTq3JujmYbtNSJ53TJ0q4G98KVZSM4EA==",
+      "license": "MIT",
+      "dependencies": {
+        "underscore": "^1.13.1"
+      },
+      "engines": {
+        "node": ">= 0.8.x"
+      }
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5569,6 +6880,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/pkg-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
+      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.2.2",
+        "exsolve": "^1.0.7",
+        "pathe": "^2.0.3"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -5595,6 +6918,45 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prebuild-install": {
@@ -5649,6 +7011,32 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prisma": {
+      "version": "6.17.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.17.1.tgz",
+      "integrity": "sha512-ac6h0sM1Tg3zu8NInY+qhP/S9KhENVaw9n1BrGKQVFu05JT5yT5Qqqmb8tMRIE3ZXvVj4xcRA5yfrsy4X7Yy5g==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/config": "6.17.1",
+        "@prisma/engines": "6.17.1"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/promise-inflight": {
@@ -5720,7 +7108,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
       "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -5821,6 +7209,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rc9": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
+      "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "destr": "^2.0.3"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -5853,6 +7252,27 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/require-directory": {
@@ -5909,6 +7329,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/resolve.exports": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
@@ -5928,6 +7358,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/retry-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-7.1.1.tgz",
+      "integrity": "sha512-hMD7odLOt3LkTjcif8aRZqi/hybjpLNgSk5oF5FCowfCjok6LukpN2bDX7R5wDmbgBQFn7YoBxSagmtXHaJYJw==",
+      "license": "MIT"
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -6039,6 +7475,86 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/sequelize": {
+      "version": "6.37.7",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.37.7.tgz",
+      "integrity": "sha512-mCnh83zuz7kQxxJirtFD7q6Huy6liPanI67BSlbzSYgVNl5eXVdE2CN1FuAeZwG1SNpGsNRCV+bJAVVnykZAFA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/sequelize"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.1.8",
+        "@types/validator": "^13.7.17",
+        "debug": "^4.3.4",
+        "dottie": "^2.0.6",
+        "inflection": "^1.13.4",
+        "lodash": "^4.17.21",
+        "moment": "^2.29.4",
+        "moment-timezone": "^0.5.43",
+        "pg-connection-string": "^2.6.1",
+        "retry-as-promised": "^7.0.4",
+        "semver": "^7.5.4",
+        "sequelize-pool": "^7.1.0",
+        "toposort-class": "^1.0.1",
+        "uuid": "^8.3.2",
+        "validator": "^13.9.0",
+        "wkx": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ibm_db": {
+          "optional": true
+        },
+        "mariadb": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "oracledb": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "pg-hstore": {
+          "optional": true
+        },
+        "snowflake-sdk": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        },
+        "tedious": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/sequelize-pool": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-7.1.0.tgz",
+      "integrity": "sha512-G9c0qlIWQSK29pR/5U2JF5dDQeqqHRragoyahj/Nx4KOOQ3CPPfzxnfqFPCSB7x5UgjOgnZ61nSxz+fjDpRlJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/sequelize/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/serve-static": {
@@ -6450,6 +7966,15 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -6535,6 +8060,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",
@@ -6781,6 +8312,13 @@
         "node": "*"
       }
     },
+    "node_modules/tinyexec": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
+      "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -6810,6 +8348,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/toposort-class": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
+      "integrity": "sha512-OsLcGGbYF3rMjPUf8oKktyvCiUxSbqMMS39m33MAjLTC1DVIH6x3WSt63/M77ihI09+Sdfk1AXvfhCEeUmC7mg==",
+      "license": "MIT"
+    },
     "node_modules/touch": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
@@ -6833,6 +8377,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6.x"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.20.6",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
+      "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/tunnel-agent": {
@@ -6884,6 +8448,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/uid-safe": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
@@ -6903,10 +8481,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/underscore": {
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
+      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
-      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz",
+      "integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==",
       "license": "MIT"
     },
     "node_modules/unique-filename": {
@@ -7072,6 +8656,15 @@
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
+    "node_modules/wkx": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
+      "integrity": "sha512-Xng/d4Ichh8uN4l0FToV/258EjMGU9MGcA0HV2d9B/ZpZB3lqQm7nkOdZdm5GhKtLLhAE7PiVQwN4eN+2YJJUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -7129,6 +8722,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -4,10 +4,14 @@
   "description": "Express.js backend for the GPT Codex Hotel project.",
   "main": "src/server.js",
   "scripts": {
-    "start": "node src/server.js",
-    "dev": "nodemon src/server.js",
+    "start": "tsx src/dining/server.ts",
+    "dev": "tsx watch src/dining/server.ts",
     "seed": "node scripts/seed.js",
-    "test": "jest"
+    "test": "jest",
+    "prisma:migrate": "prisma migrate dev",
+    "prisma:seed": "prisma db seed",
+    "hotel:start": "node src/server.js",
+    "hotel:dev": "nodemon src/server.js"
   },
   "keywords": [
     "express",
@@ -18,9 +22,11 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "@prisma/client": "^6.17.1",
     "bcrypt": "^5.1.1",
     "better-sqlite3": "^9.4.0",
     "connect-sqlite3": "^0.9.15",
+    "cookie": "^0.6.0",
     "csurf": "^1.11.0",
     "ejs": "^3.1.9",
     "express": "^5.1.0",
@@ -28,17 +34,31 @@
     "express-session": "^1.18.1",
     "express-validator": "^7.0.1",
     "helmet": "^7.0.0",
+    "ioredis": "^5.4.1",
     "joi": "^17.12.0",
+    "jsonwebtoken": "^9.0.2",
+    "pg": "^8.11.5",
+    "pg-hstore": "^2.3.4",
     "sanitize-html": "^2.13.0",
+    "sequelize": "^6.37.3",
     "socket.io": "^4.7.5",
     "uuid": "^9.0.1"
   },
   "devDependencies": {
+    "@types/cookie": "^0.6.0",
+    "@types/express": "^5.0.3",
+    "@types/node": "^24.7.2",
     "jest": "^29.7.0",
     "nodemon": "^3.1.0",
-    "supertest": "^6.3.4"
+    "prisma": "^6.17.1",
+    "supertest": "^6.3.4",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
   },
   "jest": {
     "testEnvironment": "node"
+  },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
   }
 }

--- a/prisma/migrations/0001_init/migration.sql
+++ b/prisma/migrations/0001_init/migration.sql
@@ -1,0 +1,75 @@
+-- Create tables for dining subsystem
+
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "name" TEXT,
+    "phone" TEXT,
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+CREATE TABLE "DiningTable" (
+    "id" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "capacity" INTEGER NOT NULL,
+    "x" INTEGER NOT NULL,
+    "y" INTEGER NOT NULL,
+    "rotation" INTEGER NOT NULL DEFAULT 0,
+    "zone" TEXT,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    CONSTRAINT "DiningTable_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "MenuSection" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "order" INTEGER NOT NULL,
+    CONSTRAINT "MenuSection_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "MenuItem" (
+    "id" TEXT NOT NULL,
+    "sectionId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "priceCents" INTEGER NOT NULL,
+    "vegetarian" BOOLEAN NOT NULL DEFAULT false,
+    "vegan" BOOLEAN NOT NULL DEFAULT false,
+    "glutenFree" BOOLEAN NOT NULL DEFAULT false,
+    "spicyLevel" INTEGER NOT NULL DEFAULT 0,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    CONSTRAINT "MenuItem_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "MenuItem_sectionId_fkey" FOREIGN KEY ("sectionId") REFERENCES "MenuSection"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "Staff" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "role" TEXT NOT NULL,
+    "bio" TEXT,
+    "photoUrl" TEXT,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    CONSTRAINT "Staff_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "Reservation" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL,
+    "time" TEXT NOT NULL,
+    "partySize" INTEGER NOT NULL,
+    "tableIds" TEXT[] NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'CONFIRMED',
+    "dietaryPrefs" TEXT,
+    "allergies" TEXT,
+    "contactPhone" TEXT,
+    "contactEmail" TEXT,
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Reservation_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "Reservation_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,78 @@
+// Prisma schema for dining subsystem
+// Generated as part of Dining Phase 1 setup
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id           String         @id @default(cuid())
+  email        String         @unique
+  name         String?
+  phone        String?
+  reservations Reservation[]
+}
+
+model DiningTable {
+  id        String  @id @default(cuid())
+  label     String
+  capacity  Int
+  x         Int
+  y         Int
+  rotation  Int     @default(0)
+  zone      String?
+  active    Boolean @default(true)
+}
+
+model Reservation {
+  id           String   @id @default(cuid())
+  userId       String
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  date         DateTime
+  time         String
+  partySize    Int
+  tableIds     String[]
+  status       String   @default("CONFIRMED")
+  dietaryPrefs String?
+  allergies    String?
+  contactPhone String?
+  contactEmail String?
+  notes        String?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+}
+
+model MenuSection {
+  id     String     @id @default(cuid())
+  title  String
+  order  Int
+  items  MenuItem[]
+}
+
+model MenuItem {
+  id          String      @id @default(cuid())
+  sectionId   String
+  section     MenuSection @relation(fields: [sectionId], references: [id], onDelete: Cascade)
+  name        String
+  description String?
+  priceCents  Int
+  vegetarian  Boolean     @default(false)
+  vegan       Boolean     @default(false)
+  glutenFree  Boolean     @default(false)
+  spicyLevel  Int         @default(0)
+  active      Boolean     @default(true)
+}
+
+model Staff {
+  id       String  @id @default(cuid())
+  name     String
+  role     String
+  bio      String?
+  photoUrl String?
+  active   Boolean @default(true)
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,73 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const existingTables = await prisma.diningTable.count();
+  if (existingTables === 0) {
+    const tablesToCreate = Array.from({ length: 10 }, (_, index) => {
+      const number = index + 1;
+      return {
+        label: `T${number}`,
+        capacity: number <= 4 ? 2 + (number % 4) : 6,
+        x: 50 * number,
+        y: 40 * number,
+        rotation: (number % 4) * 15,
+        zone: number <= 5 ? 'Main Hall' : 'Window',
+      };
+    });
+
+    await prisma.diningTable.createMany({ data: tablesToCreate });
+  }
+
+  const section = await prisma.menuSection.upsert({
+    where: { title: 'Chef\'s Signatures' },
+    update: {},
+    create: {
+      title: "Chef's Signatures",
+      order: 1,
+    },
+  });
+
+  const menuItems = await prisma.menuItem.count({ where: { sectionId: section.id } });
+  if (menuItems === 0) {
+    await prisma.menuItem.createMany({
+      data: [
+        {
+          sectionId: section.id,
+          name: 'Seared Scallops',
+          description: 'Day-boat scallops with citrus beurre blanc and crispy pancetta.',
+          priceCents: 3200,
+          glutenFree: true,
+        },
+        {
+          sectionId: section.id,
+          name: 'Black Garlic Wagyu',
+          description: 'Miyazaki A5 wagyu, smoked pomme puree, and charred spring onions.',
+          priceCents: 5800,
+        },
+      ],
+    });
+  }
+
+  const staffCount = await prisma.staff.count({ where: { role: 'Executive Chef' } });
+  if (staffCount === 0) {
+    await prisma.staff.create({
+      data: {
+        name: 'Elena Marquez',
+        role: 'Executive Chef',
+        bio: 'Oversees the Supper Club kitchen with a focus on sustainable coastal cuisine.',
+        photoUrl: 'https://example.com/images/staff/elena-marquez.jpg',
+      },
+    });
+  }
+}
+
+main()
+  .catch((error) => {
+    console.error('Failed to seed dining data', error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/public/css/dining.css
+++ b/public/css/dining.css
@@ -1,0 +1,456 @@
+:root {
+  --dining-bg: #05070f;
+  --dining-surface: #101424;
+  --dining-accent: #cfa858;
+  --dining-text: #f8f5ef;
+  --dining-muted: #8b8f9c;
+}
+
+[data-theme="dining"] {
+  color: var(--dining-text);
+  background: var(--dining-bg);
+  font-family: 'Outfit', sans-serif;
+}
+
+[data-theme="dining"] a {
+  color: var(--dining-accent);
+}
+
+.dining-landing,
+.dining-menu,
+.dining-reserve,
+.dining-map,
+.dining-leadership,
+.dining-staff,
+.dining-account,
+.dining-admin {
+  padding: 4rem 6vw;
+  background: var(--dining-bg);
+  color: var(--dining-text);
+}
+
+.dining-hero {
+  display: grid;
+  gap: 3rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: center;
+  margin-bottom: 4rem;
+}
+
+.dining-hero__copy h1 {
+  font-size: clamp(2.8rem, 5vw, 4rem);
+  margin-bottom: 1rem;
+}
+
+.dining-hero__copy .cta-group {
+  display: flex;
+  gap: 1rem;
+}
+
+.dining-hero__media {
+  display: flex;
+  justify-content: center;
+}
+
+.hero-orb {
+  width: 280px;
+  height: 280px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 20% 20%, rgba(207, 168, 88, 0.9), transparent 60%),
+    radial-gradient(circle at 80% 80%, rgba(80, 130, 255, 0.6), transparent 65%),
+    #0b1021;
+  box-shadow: 0 0 60px rgba(207, 168, 88, 0.35);
+}
+
+.dining-highlights {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.dining-card {
+  background: linear-gradient(145deg, rgba(16, 20, 36, 0.95), rgba(12, 16, 30, 0.9));
+  border: 1px solid rgba(207, 168, 88, 0.15);
+  border-radius: 16px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  min-height: 320px;
+}
+
+.dining-card__image {
+  background-size: cover;
+  background-position: center;
+  height: 160px;
+}
+
+.dining-card__content {
+  padding: 1.5rem;
+}
+
+.dining-overview {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 2rem;
+  margin-top: 4rem;
+  align-items: center;
+}
+
+.dining-overview__stats {
+  display: grid;
+  gap: 1rem;
+}
+
+.dining-overview__stats div {
+  background: rgba(16, 20, 36, 0.8);
+  padding: 1.5rem;
+  border-radius: 12px;
+  border: 1px solid rgba(207, 168, 88, 0.25);
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.25em;
+  font-size: 0.85rem;
+  color: var(--dining-muted);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 0.75rem 1.8rem;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn-primary {
+  background: var(--dining-accent);
+  color: #05070f;
+  box-shadow: 0 0 25px rgba(207, 168, 88, 0.3);
+  border: none;
+}
+
+.btn-outline {
+  border: 1px solid rgba(207, 168, 88, 0.45);
+  color: var(--dining-accent);
+  background: transparent;
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+}
+
+.menu-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 1.5rem;
+  margin-bottom: 3rem;
+}
+
+.menu-filters {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  background: rgba(16, 20, 36, 0.7);
+  padding: 1rem 1.5rem;
+  border-radius: 12px;
+  border: 1px solid rgba(207, 168, 88, 0.2);
+}
+
+.menu-filters fieldset {
+  border: none;
+  padding: 0;
+}
+
+.menu-section {
+  margin-bottom: 3rem;
+}
+
+.menu-section__header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.menu-section__header .divider {
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(207, 168, 88, 0.5), transparent);
+}
+
+.menu-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.menu-item {
+  background: rgba(16, 20, 36, 0.85);
+  padding: 1.5rem;
+  border-radius: 12px;
+  border: 1px solid rgba(207, 168, 88, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.menu-item header {
+  display: flex;
+  justify-content: space-between;
+}
+
+.menu-item .tags {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.menu-item .tags li {
+  background: rgba(207, 168, 88, 0.1);
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.15em;
+}
+
+.menu-item .spice {
+  color: var(--dining-muted);
+  font-size: 0.85rem;
+}
+
+.empty {
+  color: var(--dining-muted);
+}
+
+.reserve-header {
+  margin-bottom: 2rem;
+}
+
+.reserve-steps {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0.75rem;
+  list-style: none;
+  padding: 0;
+  margin: 0 0 3rem;
+}
+
+.reserve-steps li {
+  text-align: center;
+  padding: 0.75rem;
+  background: rgba(16, 20, 36, 0.6);
+  border-radius: 999px;
+  border: 1px solid rgba(207, 168, 88, 0.1);
+  font-weight: 600;
+  color: var(--dining-muted);
+}
+
+.reserve-steps li.active {
+  color: var(--dining-text);
+  border-color: var(--dining-accent);
+  box-shadow: 0 0 20px rgba(207, 168, 88, 0.2);
+}
+
+.reserve-form {
+  display: grid;
+  gap: 1rem;
+  max-width: 420px;
+}
+
+.reserve-form label {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.reserve-form input,
+.reserve-form textarea,
+.menu-filters input,
+.menu-filters select {
+  background: rgba(16, 20, 36, 0.8);
+  border: 1px solid rgba(207, 168, 88, 0.25);
+  border-radius: 10px;
+  padding: 0.75rem;
+  color: var(--dining-text);
+}
+
+.seat-stage {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  align-items: start;
+}
+
+.seat-stage__map {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+  gap: 0.75rem;
+  background: rgba(16, 20, 36, 0.9);
+  padding: 1.5rem;
+  border-radius: 16px;
+  border: 1px solid rgba(207, 168, 88, 0.2);
+}
+
+.seat-stage__sidebar {
+  background: rgba(16, 20, 36, 0.9);
+  padding: 1.5rem;
+  border-radius: 16px;
+  border: 1px solid rgba(207, 168, 88, 0.2);
+  display: grid;
+  gap: 1rem;
+}
+
+.seat-legend {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.seat-legend li {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.seat {
+  border: 1px solid rgba(207, 168, 88, 0.35);
+  border-radius: 10px;
+  padding: 0.75rem;
+  font-weight: 600;
+  background: rgba(207, 168, 88, 0.08);
+  color: var(--dining-text);
+}
+
+.seat--available {
+  background: rgba(207, 168, 88, 0.15);
+}
+
+.seat--held {
+  background: rgba(255, 142, 75, 0.15);
+  border-color: rgba(255, 142, 75, 0.6);
+}
+
+.seat--reserved {
+  background: rgba(212, 36, 78, 0.2);
+  border-color: rgba(212, 36, 78, 0.7);
+}
+
+.lock-status[data-tone="success"] {
+  color: #8bffbb;
+}
+
+.lock-status[data-tone="danger"] {
+  color: #ff9ba8;
+}
+
+.lock-status[data-tone="warning"] {
+  color: #ffcd70;
+}
+
+.leadership-grid,
+.staff-grid,
+.admin-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.leader-card,
+.staff-card,
+.admin-card,
+.reservation-card {
+  background: rgba(16, 20, 36, 0.85);
+  border-radius: 16px;
+  border: 1px solid rgba(207, 168, 88, 0.2);
+  padding: 1.5rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.leader-avatar {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(207, 168, 88, 0.5), rgba(86, 122, 255, 0.6));
+}
+
+.staff-card .badges,
+.reservation-card dl,
+.admin-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.staff-card .badges li,
+.admin-list li {
+  background: rgba(207, 168, 88, 0.12);
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+}
+
+.staff-search {
+  margin: 2rem 0;
+}
+
+.staff-search input {
+  width: min(480px, 100%);
+  background: rgba(16, 20, 36, 0.85);
+  border-radius: 999px;
+  border: 1px solid rgba(207, 168, 88, 0.25);
+  padding: 0.85rem 1.4rem;
+  color: var(--dining-text);
+}
+
+.status {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.75rem;
+}
+
+.status--confirmed {
+  color: #8bffbb;
+}
+
+.status--pending {
+  color: #ffcd70;
+}
+
+.reservation-card__actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+@media (max-width: 900px) {
+  .seat-stage {
+    grid-template-columns: 1fr;
+  }
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}

--- a/public/js/dining-seat-map.js
+++ b/public/js/dining-seat-map.js
@@ -1,0 +1,109 @@
+(function () {
+  const seatStage = document.querySelector('.seat-stage');
+  if (!seatStage) return;
+  const mapEl = seatStage.querySelector('#seat-map');
+  if (!mapEl) return;
+
+  const initialSeats = (() => {
+    try {
+      return JSON.parse(seatStage.dataset.seats || '[]');
+    } catch (error) {
+      return [];
+    }
+  })();
+
+  const statusEl = seatStage.querySelector('[data-role="status"]');
+  const lockedSeatInput = document.getElementById('locked-seat');
+  let lockId = null;
+  let lockedSeatId = null;
+
+  function renderSeats(seats) {
+    mapEl.innerHTML = '';
+    seats.forEach((seat) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = `seat seat--${seat.status}`;
+      button.dataset.seatId = seat.id;
+      button.textContent = seat.label;
+      button.disabled = seat.status !== 'available' && seat.id !== lockedSeatId;
+      button.addEventListener('click', () => handleSeatClick(seat.id));
+      mapEl.appendChild(button);
+    });
+  }
+
+  function updateStatus(message, tone = 'info') {
+    if (!statusEl) return;
+    statusEl.textContent = message;
+    statusEl.dataset.tone = tone;
+  }
+
+  const csrfHeader = window.__CSRF_TOKEN__ ? { 'CSRF-Token': window.__CSRF_TOKEN__ } : {};
+
+  async function handleSeatClick(seatId) {
+    if (lockedSeatId === seatId) {
+      if (!lockId) return;
+      const releaseResponse = await fetch('/dining/reserve/seat-release', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...csrfHeader
+        },
+        body: JSON.stringify({ seatId, lockId })
+      });
+      if (!releaseResponse.ok) {
+        updateStatus('Unable to release seat at this time.', 'warning');
+      }
+      lockId = null;
+      lockedSeatId = null;
+      if (lockedSeatInput) lockedSeatInput.value = '';
+      updateStatus('Seat released. Choose another or continue.');
+      return;
+    }
+
+    const response = await fetch('/dining/reserve/seat-lock', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...csrfHeader
+      },
+      body: JSON.stringify({ seatId })
+    });
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      updateStatus(data.error || 'Unable to hold seat.', 'danger');
+      return;
+    }
+    const data = await response.json();
+    lockId = data.lockId;
+    lockedSeatId = seatId;
+    if (lockedSeatInput) lockedSeatInput.value = seatId;
+    updateStatus(`Seat ${seatId} held for five minutes.`, 'success');
+  }
+
+  renderSeats(initialSeats);
+
+  if (typeof window.io !== 'function') {
+    updateStatus('Live updates unavailable in this browser.', 'warning');
+    return;
+  }
+
+  const socket = window.io('/dining', { transports: ['websocket', 'polling'] });
+
+  socket.on('connect_error', (err) => {
+    updateStatus('Live updates unavailable. Please refresh for latest seats.', 'warning');
+  });
+
+  socket.on('seats:snapshot', (seats) => {
+    renderSeats(seats);
+  });
+
+  socket.on('seats:update', () => {
+    fetch('/dining/map', { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+      .then((response) => response.json())
+      .then((data) => {
+        if (!data || !Array.isArray(data.seats)) return;
+        renderSeats(data.seats);
+      })
+      .catch(() => updateStatus('Unable to refresh seats from server.', 'warning'));
+  });
+})();

--- a/public/js/dining-staff-search.js
+++ b/public/js/dining-staff-search.js
@@ -1,0 +1,17 @@
+(function () {
+  const searchInput = document.querySelector('[data-staff-search]');
+  const roster = document.querySelectorAll('[data-staff-roster] .staff-card');
+  if (!searchInput || !roster.length) return;
+
+  const filterRoster = () => {
+    const query = searchInput.value.trim().toLowerCase();
+    roster.forEach((card) => {
+      const matches = !query ||
+        card.dataset.name.includes(query) ||
+        card.dataset.role.includes(query);
+      card.hidden = !matches;
+    });
+  };
+
+  searchInput.addEventListener('input', filterRoster);
+})();

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -2,6 +2,9 @@
 (() => {
   const root = document.documentElement;
   const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content');
+  if (csrfToken) {
+    window.__CSRF_TOKEN__ = csrfToken;
+  }
   const toggleButton = document.querySelector('[data-theme-toggle]');
   const navContainer = document.querySelector('[data-nav-container]');
   const navToggle = document.querySelector('[data-nav-toggle]');

--- a/src/app.js
+++ b/src/app.js
@@ -16,6 +16,8 @@ const paymentRoutes = require('./routes/payments');
 const dashboardRoutes = require('./routes/dashboard');
 const chatRoutes = require('./routes/chat');
 const adminRoutes = require('./routes/admin');
+const diningRoutes = require('./routes/dining');
+const adminDiningRoutes = require('./routes/adminDining');
 
 const app = express();
 
@@ -144,6 +146,8 @@ app.use('/', paymentLimiter, paymentRoutes);
 app.use('/', dashboardRoutes);
 app.use('/', chatLimiter, chatRoutes);
 app.use('/', adminRoutes);
+app.use('/', diningRoutes);
+app.use('/', adminDiningRoutes);
 
 app.use(notFoundHandler);
 app.use(errorHandler);

--- a/src/auth/verifySession.ts
+++ b/src/auth/verifySession.ts
@@ -1,0 +1,72 @@
+import type { NextFunction, Request, Response } from 'express';
+import jwt, { type JwtPayload } from 'jsonwebtoken';
+import { parse as parseCookie } from 'cookie';
+
+type JwtUserPayload = JwtPayload & {
+  sub?: string;
+  email?: string;
+  name?: string;
+  id?: string;
+};
+
+export interface AuthenticatedUser {
+  id: string;
+  email: string;
+  name?: string | null;
+}
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    user?: AuthenticatedUser;
+  }
+}
+
+const SESSION_COOKIE_NAME = 'session_token';
+const EXPECTED_ALGORITHMS: jwt.Algorithm[] = ['RS256'];
+
+export function verifySession(req: Request, res: Response, next: NextFunction): void {
+  try {
+    const rawCookieHeader = req.headers.cookie;
+    if (!rawCookieHeader) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+
+    const cookies = parseCookie(rawCookieHeader);
+    const token = cookies[SESSION_COOKIE_NAME];
+
+    if (!token) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+
+    const publicKey = process.env.HOTEL_JWT_PUBLIC_KEY;
+    if (!publicKey) {
+      res.status(500).json({ error: 'Server configuration error' });
+      return;
+    }
+
+    const payload = jwt.verify(token, publicKey, {
+      algorithms: EXPECTED_ALGORITHMS,
+    }) as JwtUserPayload;
+
+    const userId = payload.sub ?? payload.id;
+    const userEmail = payload.email;
+
+    if (!userId || !userEmail) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+
+    req.user = {
+      id: userId,
+      email: userEmail,
+      name: payload.name ?? null,
+    };
+
+    next();
+  } catch (error) {
+    console.warn('Failed to verify session token', error);
+    res.status(401).json({ error: 'Unauthorized' });
+  }
+}

--- a/src/db/postgres.js
+++ b/src/db/postgres.js
@@ -1,0 +1,62 @@
+const { Sequelize } = require('sequelize');
+
+let sequelize;
+
+function getSequelize() {
+  if (sequelize) {
+    return sequelize;
+  }
+
+  const {
+    DINING_DATABASE_URL,
+    DINING_DATABASE_HOST,
+    DINING_DATABASE_PORT,
+    DINING_DATABASE_USER,
+    DINING_DATABASE_PASSWORD,
+    DINING_DATABASE_NAME
+  } = process.env;
+
+  if (DINING_DATABASE_URL) {
+    sequelize = new Sequelize(DINING_DATABASE_URL, {
+      dialect: 'postgres',
+      logging: false,
+      dialectOptions: {
+        ssl:
+          process.env.DINING_DATABASE_SSL === 'true'
+            ? {
+                require: true,
+                rejectUnauthorized: false
+              }
+            : undefined
+      }
+    });
+    return sequelize;
+  }
+
+  if (DINING_DATABASE_HOST && DINING_DATABASE_USER && DINING_DATABASE_NAME) {
+    sequelize = new Sequelize(DINING_DATABASE_NAME, DINING_DATABASE_USER, DINING_DATABASE_PASSWORD, {
+      host: DINING_DATABASE_HOST,
+      port: DINING_DATABASE_PORT ? Number(DINING_DATABASE_PORT) : undefined,
+      dialect: 'postgres',
+      logging: false
+    });
+    return sequelize;
+  }
+
+  sequelize = new Sequelize('postgres://placeholder@localhost:5432/dining', {
+    dialect: 'postgres',
+    logging: false,
+    retry: { max: 0 },
+    pool: {
+      max: 0,
+      min: 0,
+      acquire: 1000,
+      idle: 1000
+    }
+  });
+  return sequelize;
+}
+
+module.exports = {
+  getSequelize
+};

--- a/src/db/redis.js
+++ b/src/db/redis.js
@@ -1,0 +1,52 @@
+const Redis = require('ioredis');
+
+let redisClient;
+
+function getRedis() {
+  if (redisClient) {
+    return redisClient;
+  }
+
+  const { REDIS_URL, REDIS_HOST, REDIS_PORT, REDIS_PASSWORD } = process.env;
+
+  try {
+    if (REDIS_URL) {
+      redisClient = new Redis(REDIS_URL, { lazyConnect: true });
+      return redisClient;
+    }
+
+    if (REDIS_HOST) {
+      redisClient = new Redis({
+        host: REDIS_HOST,
+        port: REDIS_PORT ? Number(REDIS_PORT) : 6379,
+        password: REDIS_PASSWORD,
+        lazyConnect: true
+      });
+      return redisClient;
+    }
+  } catch (error) {
+    console.warn('Failed to initialize Redis client', error);
+  }
+
+  redisClient = {
+    async connect() {
+      return Promise.resolve();
+    },
+    async quit() {
+      return Promise.resolve();
+    },
+    async set() {
+      return null;
+    },
+    async get() {
+      return null;
+    },
+    async del() {
+      return 0;
+    }
+  };
+
+  return redisClient;
+}
+
+module.exports = { getRedis };

--- a/src/dining/prismaClient.ts
+++ b/src/dining/prismaClient.ts
@@ -1,0 +1,7 @@
+import { PrismaClient } from '@prisma/client';
+
+export const prisma = new PrismaClient();
+
+process.on('beforeExit', async () => {
+  await prisma.$disconnect();
+});

--- a/src/dining/server.ts
+++ b/src/dining/server.ts
@@ -1,0 +1,87 @@
+import express, { type Request, type Response } from 'express';
+import type { Reservation } from '@prisma/client';
+import { fileURLToPath } from 'url';
+import { prisma } from './prismaClient.js';
+import { verifySession } from '../auth/verifySession.js';
+
+const app = express();
+
+app.use(express.json());
+
+app.get('/api/dining/health', (_req: Request, res: Response) => {
+  res.json({ ok: true });
+});
+
+app.get('/api/dining/menu', async (_req: Request, res: Response) => {
+  try {
+    const sections = await prisma.menuSection.findMany({
+      orderBy: { order: 'asc' },
+      include: {
+        items: {
+          where: { active: true },
+          orderBy: { name: 'asc' },
+        },
+      },
+    });
+
+    res.json({ sections });
+  } catch (error) {
+    console.error('Failed to fetch menu', error);
+    res.status(500).json({ error: 'Failed to fetch menu' });
+  }
+});
+
+app.get('/api/dining/tables', async (_req: Request, res: Response) => {
+  try {
+    const tables = await prisma.diningTable.findMany({
+      where: { active: true },
+      orderBy: { label: 'asc' },
+    });
+    res.json({ tables });
+  } catch (error) {
+    console.error('Failed to fetch dining tables', error);
+    res.status(500).json({ error: 'Failed to fetch dining tables' });
+  }
+});
+
+app.get('/api/dining/reservations/me', verifySession, async (req: Request, res: Response) => {
+  if (!req.user) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  try {
+    const reservations: Reservation[] = await prisma.reservation.findMany({
+      where: { userId: req.user.id },
+      orderBy: [{ date: 'asc' }, { time: 'asc' }],
+    });
+
+    res.json({ reservations });
+  } catch (error) {
+    console.error('Failed to fetch reservations', error);
+    res.status(500).json({ error: 'Failed to fetch reservations' });
+  }
+});
+
+const PORT = Number(process.env.DINING_PORT ?? process.env.PORT ?? 4000);
+
+export { app };
+
+if (process.argv[1]) {
+  const isMainModule = process.argv[1] === fileURLToPath(import.meta.url);
+  if (isMainModule) {
+    app.listen(PORT, () => {
+      console.log(`Dining API server listening on port ${PORT}`);
+    });
+  }
+}
+
+process.on('SIGTERM', async () => {
+  await prisma.$disconnect();
+  process.exit(0);
+});
+
+process.on('SIGINT', async () => {
+  await prisma.$disconnect();
+  process.exit(0);
+});

--- a/src/routes/adminDining.js
+++ b/src/routes/adminDining.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const { ensureAdmin } = require('../middleware/auth');
+const { listStaff } = require('../services/diningService');
+const { getCurrentSeats } = require('../services/diningSeatLocks');
+
+const router = express.Router();
+
+router.use('/admin/dining', ensureAdmin);
+
+router.get('/admin/dining', (req, res) => {
+  res.render('dining/admin/dashboard', {
+    title: 'Dining Control Center',
+    seats: getCurrentSeats(),
+    staff: listStaff()
+  });
+});
+
+router.get('/admin/dining/menu', (req, res) => {
+  res.render('dining/admin/menu', {
+    title: 'Menu Manager'
+  });
+});
+
+router.get('/admin/dining/reports', (req, res) => {
+  res.render('dining/admin/reports', {
+    title: 'Dining Reports'
+  });
+});
+
+module.exports = router;

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -6,6 +6,7 @@ const {
   createUser,
   verifyPassword
 } = require('../models/users');
+const { getUserFromRequest } = require('../utils/jwt');
 const { sanitizeString } = require('../utils/sanitize');
 
 const router = express.Router();
@@ -100,6 +101,14 @@ router.post('/logout', (req, res) => {
   req.session.destroy(() => {
     res.redirect('/');
   });
+});
+
+router.get('/auth/session', (req, res) => {
+  const user = getUserFromRequest(req);
+  if (!user) {
+    return res.status(401).json({ authenticated: false });
+  }
+  return res.json({ authenticated: true, user });
 });
 
 module.exports = router;

--- a/src/routes/dining.js
+++ b/src/routes/dining.js
@@ -1,0 +1,143 @@
+const express = require('express');
+const { ensureDiningAuthenticated, getUserFromRequest } = require('../utils/jwt');
+const {
+  initModels,
+  getMenuByCourse,
+  listLeadership,
+  listStaff,
+  listReservationsForUser
+} = require('../services/diningService');
+const { lockSeat, releaseSeat, getCurrentSeats } = require('../services/diningSeatLocks');
+
+const router = express.Router();
+
+router.use(async (req, res, next) => {
+  await initModels();
+  res.locals.layout = 'dining';
+  res.locals.diningBrand = {
+    palette: {
+      background: '#05070F',
+      surface: '#101424',
+      accent: '#CFA858'
+    },
+    name: 'Skyhaven Supper Club'
+  };
+  res.locals.diningUser = getUserFromRequest(req);
+  next();
+});
+
+router.get('/dining', (req, res) => {
+  res.render('dining/landing', {
+    title: 'Skyhaven Supper Club',
+    highlights: [
+      {
+        title: 'Chef\'s Tasting',
+        body: 'A seven-course symphony with live plating theatrics.',
+        background: 'linear-gradient(135deg, rgba(207,168,88,0.6), rgba(92,132,255,0.4))'
+      },
+      {
+        title: 'Cellar Pairings',
+        body: 'Rare allocations curated by our Master Sommelier.',
+        background: 'linear-gradient(135deg, rgba(126,188,255,0.5), rgba(28,52,96,0.8))'
+      },
+      {
+        title: 'Midnight Desserts',
+        body: 'Progressive pastry showcase lit by aurora-inspired projections.',
+        background: 'linear-gradient(135deg, rgba(212,36,78,0.4), rgba(12,20,40,0.95))'
+      }
+    ]
+  });
+});
+
+router.get('/dining/menu', async (req, res) => {
+  const { dietary, spice, priceRange } = req.query;
+  const filters = { dietary, spice, priceRange };
+  const menu = await getMenuByCourse(filters);
+  res.render('dining/menu', {
+    title: 'Supper Club Menu',
+    menu,
+    filters
+  });
+});
+
+router.get('/dining/reserve', ensureDiningAuthenticated, (req, res) => {
+  const { step = 'date' } = req.query;
+  const seats = getCurrentSeats();
+  res.render('dining/reserve', {
+    title: 'Reserve Your Evening',
+    step,
+    seats
+  });
+});
+
+router.post('/dining/reserve/seat-lock', ensureDiningAuthenticated, async (req, res) => {
+  const { seatId } = req.body;
+  const user = req.diningUser;
+  if (!seatId) {
+    return res.status(400).json({ error: 'Seat selection missing.' });
+  }
+  const lock = await lockSeat(seatId, user.id);
+  if (!lock.ok) {
+    return res.status(409).json({ error: lock.error || 'Seat unavailable.' });
+  }
+  return res.json(lock);
+});
+
+router.post('/dining/reserve/seat-release', ensureDiningAuthenticated, async (req, res) => {
+  const { seatId, lockId } = req.body;
+  if (!seatId || !lockId) {
+    return res.status(400).json({ error: 'Seat and lock required.' });
+  }
+  const result = await releaseSeat(seatId, lockId);
+  if (!result.ok) {
+    return res.status(404).json({ error: 'Seat lock not found.' });
+  }
+  return res.json({ ok: true });
+});
+
+router.get('/dining/map', ensureDiningAuthenticated, (req, res) => {
+  const seats = getCurrentSeats();
+  if (req.get('x-requested-with') === 'XMLHttpRequest') {
+    return res.json({ seats });
+  }
+  res.render('dining/map', {
+    title: 'Seat Map',
+    seats
+  });
+});
+
+router.get('/dining/leadership', (req, res) => {
+  const leaders = listLeadership();
+  res.render('dining/leadership', {
+    title: 'Meet the Culinary Collective',
+    leaders
+  });
+});
+
+router.get('/dining/staff', (req, res) => {
+  const staff = listStaff();
+  res.render('dining/staff', {
+    title: 'Our Team',
+    staff
+  });
+});
+
+router.get('/dining/account/reservations', ensureDiningAuthenticated, (req, res) => {
+  const reservations = listReservationsForUser(req.diningUser?.id);
+  res.render('dining/account', {
+    title: 'Dining Reservations',
+    reservations
+  });
+});
+
+router.get('/dining/login', (req, res) => {
+  const redirect = encodeURIComponent(req.query.redirect || '/dining');
+  res.redirect(`/login?redirect=${redirect}`);
+});
+
+router.get('/dining/join', (req, res) => {
+  const redirect = encodeURIComponent(req.query.redirect || '/dining');
+  res.redirect(`/join?redirect=${redirect}`);
+});
+
+module.exports = router;

--- a/src/services/diningSeatLocks.js
+++ b/src/services/diningSeatLocks.js
@@ -1,0 +1,105 @@
+const crypto = require('crypto');
+const EventEmitter = require('events');
+const { getRedis } = require('../db/redis');
+const { listSeats } = require('./diningService');
+
+const seatEmitter = new EventEmitter();
+const localLocks = new Map();
+
+async function ensureRedisConnected(client) {
+  if (!client || typeof client.connect !== 'function') {
+    return false;
+  }
+  if (client.status === 'ready' || client.status === 'connecting') {
+    return true;
+  }
+  try {
+    await client.connect();
+    return true;
+  } catch (error) {
+    console.warn('Redis connection failed, continuing with in-memory locks.', error.message);
+    return false;
+  }
+}
+
+function emitSnapshot() {
+  const seats = listSeats();
+  seatEmitter.emit('snapshot', seats);
+}
+
+function getCurrentSeats() {
+  return listSeats().map((seat) => {
+    const override = localLocks.get(seat.id);
+    if (override?.expiresAt > Date.now()) {
+      return { ...seat, status: override.status };
+    }
+    return seat;
+  });
+}
+
+async function lockSeat(seatId, userId, ttlSeconds = 300) {
+  const redis = getRedis();
+  const lockId = crypto.randomUUID();
+  const expiresAt = Date.now() + ttlSeconds * 1000;
+
+  const applyLock = () => {
+    localLocks.set(seatId, { userId, lockId, status: 'held', expiresAt });
+    seatEmitter.emit('update', { seatId, status: 'held', userId, lockId, expiresAt });
+    return { ok: true, lockId, expiresAt };
+  };
+
+  const redisReady = await ensureRedisConnected(redis);
+  if (redisReady && typeof redis.set === 'function') {
+    const response = await redis.set(`dining:seat:${seatId}`, lockId, 'EX', ttlSeconds, 'NX');
+    if (response === 'OK') {
+      return applyLock();
+    }
+    return { ok: false, error: 'Seat already held.' };
+  }
+
+  const existing = localLocks.get(seatId);
+  if (existing && existing.expiresAt > Date.now()) {
+    return { ok: false, error: 'Seat already held.' };
+  }
+  return applyLock();
+}
+
+async function releaseSeat(seatId, lockId) {
+  const redis = getRedis();
+  const redisReady = await ensureRedisConnected(redis);
+
+  if (redisReady && typeof redis.get === 'function') {
+    const value = await redis.get(`dining:seat:${seatId}`);
+    if (value === lockId) {
+      await redis.del(`dining:seat:${seatId}`);
+    }
+  }
+
+  const record = localLocks.get(seatId);
+  if (record && record.lockId === lockId) {
+    localLocks.delete(seatId);
+    seatEmitter.emit('update', { seatId, status: 'available' });
+    return { ok: true };
+  }
+  return { ok: false };
+}
+
+function markReserved(seatIds) {
+  const ids = Array.isArray(seatIds) ? seatIds : [seatIds];
+  ids.forEach((seatId) => {
+    const record = localLocks.get(seatId);
+    if (record) {
+      localLocks.delete(seatId);
+    }
+    seatEmitter.emit('update', { seatId, status: 'reserved' });
+  });
+}
+
+module.exports = {
+  seatEmitter,
+  getCurrentSeats,
+  lockSeat,
+  releaseSeat,
+  markReserved,
+  emitSnapshot
+};

--- a/src/services/diningService.js
+++ b/src/services/diningService.js
@@ -1,0 +1,388 @@
+const { DataTypes, Op } = require('sequelize');
+const { getSequelize } = require('../db/postgres');
+
+let initialized = false;
+let sequelizeReady = false;
+let MenuItem;
+let DiningReservation;
+let DiningSeat;
+let DiningStaff;
+
+const fallbackMenu = [
+  {
+    id: 'starter-1',
+    name: 'Golden Beet Carpaccio',
+    course: 'starters',
+    price: 18,
+    tags: ['vegetarian', 'gluten-free'],
+    spiceLevel: 1,
+    description: 'Shaved beets, pistachio praline, Meyer lemon gel.'
+  },
+  {
+    id: 'starter-2',
+    name: 'Torched Hamachi Mosaic',
+    course: 'starters',
+    price: 24,
+    tags: ['gluten-free'],
+    spiceLevel: 2,
+    description: 'Yuzu kosho, compressed cucumber, sesame tuile.'
+  },
+  {
+    id: 'main-1',
+    name: 'Wagyu Striploin',
+    course: 'mains',
+    price: 64,
+    tags: [],
+    spiceLevel: 1,
+    description: 'Charred onion soubise, truffle pomme purée.'
+  },
+  {
+    id: 'main-2',
+    name: 'Black Garlic Cauliflower Steak',
+    course: 'mains',
+    price: 36,
+    tags: ['vegan', 'gluten-free'],
+    spiceLevel: 2,
+    description: 'Harissa, preserved lemon, smoked almond cream.'
+  },
+  {
+    id: 'dessert-1',
+    name: '64% Chocolate Marquise',
+    course: 'desserts',
+    price: 19,
+    tags: ['vegetarian'],
+    spiceLevel: 0,
+    description: 'Hazelnut praline, salted caramel, cocoa nib crunch.'
+  },
+  {
+    id: 'drink-1',
+    name: 'Celestial Negroni',
+    course: 'drinks',
+    price: 21,
+    tags: ['gluten-free'],
+    spiceLevel: 1,
+    description: 'Barrel-aged gin, cacao vermouth, amaro, orange oils.'
+  }
+];
+
+const fallbackLeadership = [
+  {
+    id: 'dir-1',
+    name: 'Isabella Marchetti',
+    title: 'Director of Culinary Experiences',
+    focus: 'Vision & Guest Journey',
+    bio: 'Former Michelin-starred GM bringing theatrical dining to Skyhaven.',
+    photo: '/images/dining/leadership/isabella.jpg'
+  },
+  {
+    id: 'chef-1',
+    name: 'Kenji Nakamoto',
+    title: 'Executive Chef',
+    focus: 'Modern kaiseki-inspired tasting menus',
+    bio: 'Sourced from Kyoto, blending precision with seasonal Rocky Mountain ingredients.',
+    photo: '/images/dining/leadership/kenji.jpg'
+  },
+  {
+    id: 'pastry-1',
+    name: 'Aurora Chen',
+    title: 'Pastry Chef',
+    focus: 'Edible art installations',
+    bio: 'Inventor of the luminescent pavlova series and a lifelong chocolate sculptor.',
+    photo: '/images/dining/leadership/aurora.jpg'
+  },
+  {
+    id: 'som-1',
+    name: 'Thierry Dubois',
+    title: 'Head Sommelier',
+    focus: 'Rare allocations & tableside storytelling',
+    bio: 'Certified Master Sommelier specializing in biodynamic pairings.',
+    photo: '/images/dining/leadership/thierry.jpg'
+  },
+  {
+    id: 'foh-1',
+    name: 'Sasha Patel',
+    title: 'Front of House Director',
+    focus: 'Service choreography',
+    bio: 'Leads a synchronized team delivering choreographed service cues.',
+    photo: '/images/dining/leadership/sasha.jpg'
+  },
+  {
+    id: 'boh-1',
+    name: 'Luis Romero',
+    title: 'Back of House Director',
+    focus: 'Culinary operations',
+    bio: 'Drives mise-en-place precision and nightly kitchen briefings.',
+    photo: '/images/dining/leadership/luis.jpg'
+  }
+];
+
+const fallbackStaff = [
+  {
+    id: 'staff-1',
+    name: 'Rowan Lee',
+    role: 'Captain',
+    badges: ['Lead Service', 'Wine Studio'],
+    nextShift: '2024-07-01T17:00:00Z'
+  },
+  {
+    id: 'staff-2',
+    name: 'Emilia Hart',
+    role: 'Pastry Sous Chef',
+    badges: ['Sugar Artist'],
+    nextShift: '2024-07-01T15:00:00Z'
+  },
+  {
+    id: 'staff-3',
+    name: 'Malik Carter',
+    role: 'Sommelier',
+    badges: ['Spirits Curator'],
+    nextShift: '2024-07-02T17:00:00Z'
+  }
+];
+
+const fallbackSeats = [
+  { id: 'A1', label: 'A1', capacity: 2, zone: 'Atrium', status: 'available' },
+  { id: 'A2', label: 'A2', capacity: 2, zone: 'Atrium', status: 'available' },
+  { id: 'A3', label: 'A3', capacity: 4, zone: 'Atrium', status: 'held' },
+  { id: 'B1', label: 'B1', capacity: 6, zone: 'Garden', status: 'reserved' },
+  { id: 'B2', label: 'B2', capacity: 4, zone: 'Garden', status: 'available' },
+  { id: 'C1', label: 'C1', capacity: 2, zone: 'Chef\'s Counter', status: 'available' }
+];
+
+async function initModels() {
+  if (initialized) {
+    return;
+  }
+  initialized = true;
+
+  try {
+    const sequelize = getSequelize();
+
+    MenuItem = sequelize.define(
+      'DiningMenuItem',
+      {
+        id: {
+          type: DataTypes.UUID,
+          defaultValue: DataTypes.UUIDV4,
+          primaryKey: true
+        },
+        name: DataTypes.STRING,
+        description: DataTypes.TEXT,
+        course: DataTypes.STRING,
+        price: DataTypes.FLOAT,
+        tags: {
+          type: DataTypes.ARRAY(DataTypes.STRING),
+          allowNull: false,
+          defaultValue: []
+        },
+        spiceLevel: {
+          type: DataTypes.INTEGER,
+          allowNull: false,
+          defaultValue: 0
+        },
+        active: {
+          type: DataTypes.BOOLEAN,
+          allowNull: false,
+          defaultValue: true
+        }
+      },
+      {
+        tableName: 'dining_menu_items',
+        timestamps: true
+      }
+    );
+
+    DiningReservation = sequelize.define(
+      'DiningReservation',
+      {
+        id: {
+          type: DataTypes.UUID,
+          defaultValue: DataTypes.UUIDV4,
+          primaryKey: true
+        },
+        userId: DataTypes.STRING,
+        diningDate: DataTypes.DATE,
+        partySize: DataTypes.INTEGER,
+        seatIds: {
+          type: DataTypes.ARRAY(DataTypes.STRING),
+          defaultValue: []
+        },
+        dietaryNotes: DataTypes.TEXT,
+        contactPhone: DataTypes.STRING,
+        specialRequests: DataTypes.TEXT,
+        status: {
+          type: DataTypes.STRING,
+          defaultValue: 'pending'
+        },
+        depositAmount: {
+          type: DataTypes.FLOAT,
+          defaultValue: 0
+        }
+      },
+      {
+        tableName: 'dining_reservations',
+        timestamps: true
+      }
+    );
+
+    DiningSeat = sequelize.define(
+      'DiningSeat',
+      {
+        id: {
+          type: DataTypes.STRING,
+          primaryKey: true
+        },
+        label: DataTypes.STRING,
+        capacity: DataTypes.INTEGER,
+        zone: DataTypes.STRING,
+        status: DataTypes.STRING
+      },
+      {
+        tableName: 'dining_seats',
+        timestamps: true
+      }
+    );
+
+    DiningStaff = sequelize.define(
+      'DiningStaff',
+      {
+        id: {
+          type: DataTypes.UUID,
+          defaultValue: DataTypes.UUIDV4,
+          primaryKey: true
+        },
+        name: DataTypes.STRING,
+        role: DataTypes.STRING,
+        badges: {
+          type: DataTypes.ARRAY(DataTypes.STRING),
+          defaultValue: []
+        },
+        nextShift: DataTypes.DATE,
+        bio: DataTypes.TEXT,
+        headshotUrl: DataTypes.STRING
+      },
+      {
+        tableName: 'dining_staff',
+        timestamps: true
+      }
+    );
+
+    await sequelize.sync({ alter: false });
+    sequelizeReady = true;
+  } catch (error) {
+    console.warn('Dining models falling back to in-memory data. Reason:', error.message);
+    sequelizeReady = false;
+  }
+}
+
+function normalizeFilters({ dietary, spice, priceRange } = {}) {
+  const parseList = (value) => (Array.isArray(value) ? value.filter(Boolean) : value ? [value] : []);
+  const parsedDietary = parseList(dietary);
+  const parsedSpice = parseList(spice).map((value) => Number(value));
+  const parsedPrice = priceRange ? priceRange.split('-').map((value) => Number(value)) : [];
+  return { parsedDietary, parsedSpice, parsedPrice };
+}
+
+function groupMenuByCourse(items) {
+  return items.reduce((acc, item) => {
+    const bucket = acc[item.course] || [];
+    bucket.push(item);
+    acc[item.course] = bucket;
+    return acc;
+  }, {});
+}
+
+function filterFallbackMenu(filters) {
+  const { parsedDietary, parsedSpice, parsedPrice } = normalizeFilters(filters);
+  return fallbackMenu.filter((item) => {
+    if (parsedDietary.length && !parsedDietary.every((tag) => item.tags.includes(tag))) {
+      return false;
+    }
+    if (parsedSpice.length && !parsedSpice.includes(item.spiceLevel)) {
+      return false;
+    }
+    if (parsedPrice.length === 2) {
+      const [min, max] = parsedPrice;
+      if (item.price < min || item.price > max) {
+        return false;
+      }
+    }
+    return true;
+  });
+}
+
+async function getMenuByCourse(filters = {}) {
+  if (sequelizeReady && MenuItem) {
+    try {
+      const { parsedDietary, parsedSpice, parsedPrice } = normalizeFilters(filters);
+      const where = { active: true };
+      if (parsedDietary.length) {
+        where.tags = { [Op.contains]: parsedDietary };
+      }
+      if (parsedSpice.length) {
+        where.spiceLevel = parsedSpice;
+      }
+      if (parsedPrice.length === 2) {
+        where.price = { [Op.between]: parsedPrice };
+      }
+      const items = await MenuItem.findAll({
+        where,
+        order: [
+          ['course', 'ASC'],
+          ['name', 'ASC']
+        ]
+      });
+      const plainItems = items.map((item) => item.toJSON());
+      return groupMenuByCourse(plainItems);
+    } catch (error) {
+      console.warn('Falling back to static dining menu.', error.message);
+    }
+  }
+  const filtered = filterFallbackMenu(filters);
+  return groupMenuByCourse(filtered);
+}
+
+function listLeadership() {
+  return fallbackLeadership;
+}
+
+function listStaff() {
+  return fallbackStaff;
+}
+
+function listSeats() {
+  return fallbackSeats;
+}
+
+function listReservationsForUser(userId) {
+  if (!userId) return [];
+  return [
+    {
+      id: 'res-1',
+      diningDate: '2024-07-01T19:00:00Z',
+      partySize: 2,
+      seatIds: ['A1', 'A2'],
+      status: 'confirmed',
+      depositAmount: 50,
+      dietaryNotes: 'No shellfish'
+    },
+    {
+      id: 'res-2',
+      diningDate: '2024-08-15T21:00:00Z',
+      partySize: 4,
+      seatIds: ['C1'],
+      status: 'pending',
+      depositAmount: 0,
+      dietaryNotes: 'Celebrating anniversary'
+    }
+  ];
+}
+
+module.exports = {
+  initModels,
+  getMenuByCourse,
+  listLeadership,
+  listStaff,
+  listSeats,
+  listReservationsForUser
+};

--- a/src/utils/jwt.js
+++ b/src/utils/jwt.js
@@ -1,0 +1,72 @@
+const jwt = require('jsonwebtoken');
+const cookie = require('cookie');
+
+function parseCookies(req) {
+  const header = req.headers?.cookie || req.request?.headers?.cookie;
+  if (!header) return {};
+  try {
+    return cookie.parse(header);
+  } catch (error) {
+    return {};
+  }
+}
+
+function getSessionToken(req) {
+  const cookies = parseCookies(req);
+  return cookies.session_token || null;
+}
+
+function verifyHotelToken(token) {
+  if (!token) return null;
+  const { HOTEL_JWT_PUBLIC_KEY, HOTEL_JWT_ALGORITHMS } = process.env;
+  const algorithms = HOTEL_JWT_ALGORITHMS ? HOTEL_JWT_ALGORITHMS.split(',') : ['RS256', 'HS256'];
+  const verifyOptions = { algorithms };
+
+  try {
+    if (HOTEL_JWT_PUBLIC_KEY) {
+      return jwt.verify(token, HOTEL_JWT_PUBLIC_KEY, verifyOptions);
+    }
+    // Without public key fallback to shared secret env for local dev
+    if (process.env.HOTEL_JWT_SECRET) {
+      return jwt.verify(token, process.env.HOTEL_JWT_SECRET, verifyOptions);
+    }
+    return jwt.decode(token);
+  } catch (error) {
+    return null;
+  }
+}
+
+function getUserFromRequest(req) {
+  const token = getSessionToken(req);
+  const payload = verifyHotelToken(token);
+  if (!payload) return null;
+  if (payload.user) {
+    return payload.user;
+  }
+  const { sub, email, name, role } = payload;
+  return {
+    id: sub,
+    email,
+    name,
+    role: role || 'guest'
+  };
+}
+
+function ensureDiningAuthenticated(req, res, next) {
+  const user = getUserFromRequest(req);
+  if (user) {
+    req.diningUser = user;
+    res.locals.diningUser = user;
+    return next();
+  }
+  const redirectTarget = `/login?redirect=${encodeURIComponent(req.originalUrl)}`;
+  return res.redirect(redirectTarget);
+}
+
+module.exports = {
+  parseCookies,
+  getSessionToken,
+  verifyHotelToken,
+  getUserFromRequest,
+  ensureDiningAuthenticated
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ESNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node", "express"]
+  },
+  "include": ["src", "prisma"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/views/dining/account.ejs
+++ b/views/dining/account.ejs
@@ -1,0 +1,45 @@
+<%- include('../partials/head', { pageTitle: title, hotelName, csrfToken, darkMode }) %>
+<link rel="stylesheet" href="/css/dining.css">
+<%- include('../partials/nav') %>
+<main class="dining-account" data-theme="dining">
+  <header>
+    <h1>Your dining reservations</h1>
+    <p>Track, modify, or cancel upcoming Supper Club experiences.</p>
+  </header>
+  <section class="reservation-list">
+    <% if(reservations.length === 0) { %>
+      <p>You have no upcoming dining reservations yet.</p>
+      <a class="btn btn-primary" href="/dining/reserve">Plan an evening</a>
+    <% } %>
+    <% reservations.forEach((reservation) => { %>
+      <article class="reservation-card">
+        <header>
+          <h2><time datetime="<%= reservation.diningDate %>"><%= new Date(reservation.diningDate).toLocaleString() %></time></h2>
+          <p class="status status--<%= reservation.status %>"><%= reservation.status %></p>
+        </header>
+        <dl>
+          <div>
+            <dt>Party size</dt>
+            <dd><%= reservation.partySize %></dd>
+          </div>
+          <div>
+            <dt>Seats</dt>
+            <dd><%= reservation.seatIds.join(', ') %></dd>
+          </div>
+          <div>
+            <dt>Deposit</dt>
+            <dd>$<%= reservation.depositAmount.toFixed(2) %></dd>
+          </div>
+        </dl>
+        <% if(reservation.dietaryNotes) { %>
+          <p class="notes">Notes: <%= reservation.dietaryNotes %></p>
+        <% } %>
+        <div class="reservation-card__actions">
+          <button class="btn btn-outline" type="button">Modify</button>
+          <button class="btn btn-outline" type="button">Cancel</button>
+        </div>
+      </article>
+    <% }) %>
+  </section>
+</main>
+<%- include('../partials/footer') %>

--- a/views/dining/admin/dashboard.ejs
+++ b/views/dining/admin/dashboard.ejs
@@ -1,0 +1,36 @@
+<%- include('../../partials/head', { pageTitle: title, hotelName, csrfToken, darkMode }) %>
+<link rel="stylesheet" href="/css/dining.css">
+<%- include('../../partials/nav') %>
+<main class="dining-admin" data-theme="dining">
+  <header class="admin-header">
+    <h1>Dining Control Center</h1>
+    <p>Monitor live seat availability, reservations, and staff coverage.</p>
+  </header>
+  <section class="admin-grid">
+    <article class="admin-card">
+      <h2>Seat status</h2>
+      <ul class="admin-list">
+        <% seats.forEach((seat) => { %>
+          <li><strong><%= seat.label %></strong> &mdash; <%= seat.status %> · seats <%= seat.capacity %></li>
+        <% }) %>
+      </ul>
+    </article>
+    <article class="admin-card">
+      <h2>Staff coverage</h2>
+      <ul class="admin-list">
+        <% staff.forEach((member) => { %>
+          <li><strong><%= member.name %></strong> &mdash; <%= member.role %></li>
+        <% }) %>
+      </ul>
+    </article>
+    <article class="admin-card">
+      <h2>Exports</h2>
+      <p>Download nightly reservations and staffing reports for offline review.</p>
+      <div class="cta-group">
+        <button class="btn btn-outline" type="button">Reservations CSV</button>
+        <button class="btn btn-outline" type="button">Shifts CSV</button>
+      </div>
+    </article>
+  </section>
+</main>
+<%- include('../../partials/footer') %>

--- a/views/dining/admin/menu.ejs
+++ b/views/dining/admin/menu.ejs
@@ -1,0 +1,30 @@
+<%- include('../../partials/head', { pageTitle: title, hotelName, csrfToken, darkMode }) %>
+<link rel="stylesheet" href="/css/dining.css">
+<%- include('../../partials/nav') %>
+<main class="dining-admin" data-theme="dining">
+  <header class="admin-header">
+    <h1>Menu manager</h1>
+    <p>Create, update, and publish Supper Club menu items.</p>
+  </header>
+  <section class="admin-form">
+    <form class="menu-admin-form">
+      <label>Name <input type="text" name="name" required></label>
+      <label>Course
+        <select name="course">
+          <option value="starters">Starters</option>
+          <option value="mains">Mains</option>
+          <option value="desserts">Desserts</option>
+          <option value="drinks">Drinks</option>
+        </select>
+      </label>
+      <label>Price <input type="number" name="price" step="0.01" required></label>
+      <label>Tags <input type="text" name="tags" placeholder="Comma separated"></label>
+      <label>Description <textarea name="description" rows="4"></textarea></label>
+      <div class="cta-group">
+        <button class="btn btn-primary" type="submit">Save</button>
+        <button class="btn btn-outline" type="reset">Reset</button>
+      </div>
+    </form>
+  </section>
+</main>
+<%- include('../../partials/footer') %>

--- a/views/dining/admin/reports.ejs
+++ b/views/dining/admin/reports.ejs
@@ -1,0 +1,22 @@
+<%- include('../../partials/head', { pageTitle: title, hotelName, csrfToken, darkMode }) %>
+<link rel="stylesheet" href="/css/dining.css">
+<%- include('../../partials/nav') %>
+<main class="dining-admin" data-theme="dining">
+  <header class="admin-header">
+    <h1>Reports</h1>
+    <p>Export high-level metrics and nightly performance snapshots.</p>
+  </header>
+  <section class="admin-grid">
+    <article class="admin-card">
+      <h2>Revenue overview</h2>
+      <p>Projected vs actual covers, average spend per guest, and deposit collection rate.</p>
+      <button class="btn btn-outline" type="button">Download revenue CSV</button>
+    </article>
+    <article class="admin-card">
+      <h2>Guest sentiment</h2>
+      <p>Pull qualitative notes from the guest experience team and sentiment scores.</p>
+      <button class="btn btn-outline" type="button">Download sentiment CSV</button>
+    </article>
+  </section>
+</main>
+<%- include('../../partials/footer') %>

--- a/views/dining/landing.ejs
+++ b/views/dining/landing.ejs
@@ -1,0 +1,57 @@
+<%- include('../partials/head', { pageTitle: title, hotelName, csrfToken, darkMode }) %>
+<link rel="stylesheet" href="/css/dining.css">
+<%- include('../partials/nav') %>
+<%- include('../partials/alerts') %>
+<main class="dining-landing" data-theme="dining">
+  <section class="dining-hero">
+    <div class="dining-hero__copy">
+      <p class="eyebrow">Skyhaven Supper Club</p>
+      <h1>Where twilight becomes a tasting.</h1>
+      <p>
+        Experience a progressive culinary story bathed in aurora lighting, rare vintages, and impeccable choreography.
+      </p>
+      <div class="cta-group">
+        <a class="btn btn-primary" href="/dining/menu">View Menu</a>
+        <a class="btn btn-outline" href="/dining/reserve">Reserve an Evening</a>
+      </div>
+    </div>
+    <div class="dining-hero__media" role="presentation">
+      <div class="hero-orb"></div>
+    </div>
+  </section>
+  <section class="dining-highlights">
+    <% highlights.forEach((highlight) => { %>
+      <article class="dining-card">
+        <div class="dining-card__image" style="background-image: <%= highlight.background %>"></div>
+        <div class="dining-card__content">
+          <h2><%= highlight.title %></h2>
+          <p><%= highlight.body %></p>
+        </div>
+      </article>
+    <% }) %>
+  </section>
+  <section class="dining-overview">
+    <div>
+      <h2>Integrated with your Skyhaven journey</h2>
+      <p>
+        Already a hotel guest? Your Supper Club profile uses the same secure identity and preferences so every dining
+        touchpoint feels choreographed just for you.
+      </p>
+    </div>
+    <dl class="dining-overview__stats">
+      <div>
+        <dt>Signature seats</dt>
+        <dd>42 guests</dd>
+      </div>
+      <div>
+        <dt>Cellar allocations</dt>
+        <dd>1200 labels</dd>
+      </div>
+      <div>
+        <dt>Chef table intervals</dt>
+        <dd>Every 27 minutes</dd>
+      </div>
+    </dl>
+  </section>
+</main>
+<%- include('../partials/footer') %>

--- a/views/dining/leadership.ejs
+++ b/views/dining/leadership.ejs
@@ -1,0 +1,25 @@
+<%- include('../partials/head', { pageTitle: title, hotelName, csrfToken, darkMode }) %>
+<link rel="stylesheet" href="/css/dining.css">
+<%- include('../partials/nav') %>
+<main class="dining-leadership" data-theme="dining">
+  <header>
+    <h1>The Culinary Collective</h1>
+    <p>Meet the team orchestrating each sensory movement of your evening.</p>
+  </header>
+  <section class="leadership-grid">
+    <% leaders.forEach((leader) => { %>
+      <article class="leader-card">
+        <div class="leader-card__image" role="presentation">
+          <div class="leader-avatar" aria-hidden="true"></div>
+        </div>
+        <div class="leader-card__content">
+          <h2><%= leader.name %></h2>
+          <p class="title"><%= leader.title %></p>
+          <p class="focus">Signature: <%= leader.focus %></p>
+          <p><%= leader.bio %></p>
+        </div>
+      </article>
+    <% }) %>
+  </section>
+</main>
+<%- include('../partials/footer') %>

--- a/views/dining/map.ejs
+++ b/views/dining/map.ejs
@@ -1,0 +1,24 @@
+<%- include('../partials/head', { pageTitle: title, hotelName, csrfToken, darkMode }) %>
+<link rel="stylesheet" href="/css/dining.css">
+<script defer src="/js/dining-seat-map.js"></script>
+<%- include('../partials/nav') %>
+<main class="dining-map" data-theme="dining">
+  <header>
+    <h1>Seat map</h1>
+    <p>Live view of Supper Club availability. Seats update in real-time as guests hold and confirm.</p>
+  </header>
+  <div class="seat-stage" data-seats='<%- JSON.stringify(seats) %>'>
+    <div class="seat-stage__map" id="seat-map" aria-live="polite"></div>
+    <aside class="seat-stage__sidebar">
+      <h2>Legend</h2>
+      <ul class="seat-legend">
+        <li><span class="seat seat--available"></span> Available</li>
+        <li><span class="seat seat--held"></span> Held</li>
+        <li><span class="seat seat--reserved"></span> Reserved</li>
+      </ul>
+      <div class="lock-status" data-role="status"></div>
+      <p>Lock a seat directly from the map or return to the reservation stepper to continue your booking.</p>
+    </aside>
+  </div>
+</main>
+<%- include('../partials/footer') %>

--- a/views/dining/menu.ejs
+++ b/views/dining/menu.ejs
@@ -1,0 +1,68 @@
+<%- include('../partials/head', { pageTitle: title, hotelName, csrfToken, darkMode }) %>
+<link rel="stylesheet" href="/css/dining.css">
+<%- include('../partials/nav') %>
+<%- include('../partials/alerts') %>
+<main class="dining-menu" data-theme="dining">
+  <header class="menu-header">
+    <div>
+      <p class="eyebrow">Chef Kenji Nakamoto presents</p>
+      <h1>Seasonal Menu</h1>
+    </div>
+    <form class="menu-filters" method="get">
+      <fieldset>
+        <legend>Dietary</legend>
+        <label><input type="checkbox" name="dietary" value="vegetarian" <% if(Array.isArray(filters.dietary) ? filters.dietary.includes('vegetarian') : filters.dietary === 'vegetarian') { %>checked<% } %>> Vegetarian</label>
+        <label><input type="checkbox" name="dietary" value="vegan" <% if(Array.isArray(filters.dietary) ? filters.dietary.includes('vegan') : filters.dietary === 'vegan') { %>checked<% } %>> Vegan</label>
+        <label><input type="checkbox" name="dietary" value="gluten-free" <% if(Array.isArray(filters.dietary) ? filters.dietary.includes('gluten-free') : filters.dietary === 'gluten-free') { %>checked<% } %>> Gluten-free</label>
+      </fieldset>
+      <fieldset>
+        <legend>Spice</legend>
+        <label><input type="checkbox" name="spice" value="0" <% if(Array.isArray(filters.spice) ? filters.spice.includes('0') : filters.spice === '0') { %>checked<% } %>> Gentle</label>
+        <label><input type="checkbox" name="spice" value="1" <% if(Array.isArray(filters.spice) ? filters.spice.includes('1') : filters.spice === '1') { %>checked<% } %>> Warm</label>
+        <label><input type="checkbox" name="spice" value="2" <% if(Array.isArray(filters.spice) ? filters.spice.includes('2') : filters.spice === '2') { %>checked<% } %>> Ember</label>
+      </fieldset>
+      <fieldset>
+        <legend>Price</legend>
+        <select name="priceRange">
+          <option value="">All</option>
+          <option value="0-25" <% if(filters.priceRange === '0-25') { %>selected<% } %>>Under $25</option>
+          <option value="25-50" <% if(filters.priceRange === '25-50') { %>selected<% } %>>$25-$50</option>
+          <option value="50-100" <% if(filters.priceRange === '50-100') { %>selected<% } %>>$50-$100</option>
+        </select>
+      </fieldset>
+      <button type="submit" class="btn btn-outline">Filter</button>
+    </form>
+  </header>
+  <% const sections = { starters: 'Starters', mains: 'Mains', desserts: 'Desserts', drinks: 'Drinks' }; %>
+  <% Object.keys(sections).forEach((sectionKey) => { %>
+    <section class="menu-section">
+      <div class="menu-section__header">
+        <h2><%= sections[sectionKey] %></h2>
+        <span class="divider"></span>
+      </div>
+      <div class="menu-grid">
+        <% (menu[sectionKey] || []).forEach((item) => { %>
+          <article class="menu-item">
+            <header>
+              <h3><%= item.name %></h3>
+              <span class="price">$<%= item.price %></span>
+            </header>
+            <p><%= item.description %></p>
+            <% if(item.tags && item.tags.length) { %>
+              <ul class="tags">
+                <% item.tags.forEach((tag) => { %>
+                  <li><%= tag %></li>
+                <% }) %>
+              </ul>
+            <% } %>
+            <p class="spice">Heat Level: <%= ['None', 'Warm', 'Ember'][item.spiceLevel] || 'Gentle' %></p>
+          </article>
+        <% }) %>
+        <% if(!(menu[sectionKey] || []).length) { %>
+          <p class="empty">No selections in this category for your filters yet.</p>
+        <% } %>
+      </div>
+    </section>
+  <% }) %>
+</main>
+<%- include('../partials/footer') %>

--- a/views/dining/reserve.ejs
+++ b/views/dining/reserve.ejs
@@ -1,0 +1,67 @@
+<%- include('../partials/head', { pageTitle: title, hotelName, csrfToken, darkMode }) %>
+<link rel="stylesheet" href="/css/dining.css">
+<script defer src="/js/dining-seat-map.js"></script>
+<%- include('../partials/nav') %>
+<%- include('../partials/alerts') %>
+<main class="dining-reserve" data-theme="dining">
+  <header class="reserve-header">
+    <h1>Reserve your evening</h1>
+    <p>Five steps stand between you and an unforgettable tasting.</p>
+  </header>
+  <ol class="reserve-steps">
+    <li class="<%= step === 'date' ? 'active' : '' %>">Date &amp; Time</li>
+    <li class="<%= step === 'party' ? 'active' : '' %>">Party size</li>
+    <li class="<%= step === 'seating' ? 'active' : '' %>">Seat selection</li>
+    <li class="<%= step === 'details' ? 'active' : '' %>">Guest details</li>
+    <li class="<%= step === 'review' ? 'active' : '' %>">Review &amp; pay</li>
+  </ol>
+  <section class="reserve-stage" data-stage="<%= step %>">
+    <% if(step === 'date') { %>
+      <form class="reserve-form" method="get">
+        <input type="hidden" name="step" value="party">
+        <label>Date <input type="date" name="date" required></label>
+        <label>Time <input type="time" name="time" required></label>
+        <button class="btn btn-primary" type="submit">Continue</button>
+      </form>
+    <% } %>
+    <% if(step === 'party') { %>
+      <form class="reserve-form" method="get">
+        <input type="hidden" name="step" value="seating">
+        <label>Party size <input type="number" name="partySize" min="1" max="8" required></label>
+        <button class="btn btn-primary" type="submit">Select seats</button>
+      </form>
+    <% } %>
+    <% if(step === 'seating') { %>
+      <div class="seat-stage" data-seats='<%- JSON.stringify(seats) %>'>
+        <div class="seat-stage__map" id="seat-map" aria-live="polite"></div>
+        <aside class="seat-stage__sidebar">
+          <h2>Live availability</h2>
+          <p>Select the seats that match your party. They will be held for five minutes.</p>
+          <div class="lock-status" data-role="status"></div>
+          <form class="reserve-form" method="get">
+            <input type="hidden" name="step" value="details">
+            <input type="hidden" name="lockedSeat" id="locked-seat" required>
+            <button class="btn btn-primary" type="submit">Continue</button>
+          </form>
+        </aside>
+      </div>
+    <% } %>
+    <% if(step === 'details') { %>
+      <form class="reserve-form" method="get">
+        <input type="hidden" name="step" value="review">
+        <label>Primary phone <input type="tel" name="phone" required></label>
+        <label>Dietary notes <textarea name="dietary" rows="3"></textarea></label>
+        <label>Celebration or notes <textarea name="notes" rows="3"></textarea></label>
+        <button class="btn btn-primary" type="submit">Review</button>
+      </form>
+    <% } %>
+    <% if(step === 'review') { %>
+      <article class="reserve-review">
+        <h2>Review &amp; secure</h2>
+        <p>Deposit required for weekend tastings. A concierge will confirm within minutes.</p>
+        <button class="btn btn-primary">Place reservation</button>
+      </article>
+    <% } %>
+  </section>
+</main>
+<%- include('../partials/footer') %>

--- a/views/dining/staff.ejs
+++ b/views/dining/staff.ejs
@@ -1,0 +1,31 @@
+<%- include('../partials/head', { pageTitle: title, hotelName, csrfToken, darkMode }) %>
+<link rel="stylesheet" href="/css/dining.css">
+<script defer src="/js/dining-staff-search.js"></script>
+<%- include('../partials/nav') %>
+<main class="dining-staff" data-theme="dining">
+  <header>
+    <h1>Staff Roster</h1>
+    <p>Search the Supper Club team, explore specialties, and view upcoming shifts.</p>
+  </header>
+  <section class="staff-search">
+    <label for="staff-search-input" class="sr-only">Search staff</label>
+    <input id="staff-search-input" type="search" placeholder="Search by name or role" data-staff-search>
+  </section>
+  <section class="staff-grid" data-staff-roster>
+    <% staff.forEach((member) => { %>
+      <article class="staff-card" data-name="<%= member.name.toLowerCase() %>" data-role="<%= member.role.toLowerCase() %>">
+        <header>
+          <h2><%= member.name %></h2>
+          <p class="role"><%= member.role %></p>
+        </header>
+        <ul class="badges">
+          <% member.badges.forEach((badge) => { %>
+            <li><%= badge %></li>
+          <% }) %>
+        </ul>
+        <p class="shift">Next shift: <time datetime="<%= member.nextShift %>"><%= new Date(member.nextShift).toLocaleString() %></time></p>
+      </article>
+    <% }) %>
+  </section>
+</main>
+<%- include('../partials/footer') %>

--- a/views/partials/nav.ejs
+++ b/views/partials/nav.ejs
@@ -24,6 +24,7 @@
         <a href="/rooms" class="nav-link">Rooms</a>
         <a href="/amenities" class="nav-link">Amenities</a>
         <a href="/leadership" class="nav-link">Leadership</a>
+        <a href="/dining" class="nav-link">Dining</a>
         <a href="/book" class="nav-link">Book</a>
         <a href="/contact" class="nav-link">Contact</a>
         <% if (currentUser) { %>


### PR DESCRIPTION
## Summary
- add Prisma schema, migration, and seed data for the dining domain tables and sample content
- introduce shared JWT verification middleware and TypeScript dining API server exposing health, menu, tables, and reservations endpoints
- configure tooling with TypeScript, tsx, and Prisma scripts plus environment documentation for the new dining subsystem

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ec6737b9a883239cde4184376b2bbd