### PR TITLE
Implement dining availability holds with real-time seat map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,12 +24,13 @@
         "ioredis": "^5.4.1",
         "joi": "^17.12.0",
         "jsonwebtoken": "^9.0.2",
+        "multer": "^1.4.5-lts.2",
         "pg": "^8.11.5",
         "pg-hstore": "^2.3.4",
-        "multer": "^1.4.5-lts.2",
         "sanitize-html": "^2.13.0",
         "sequelize": "^6.37.3",
         "socket.io": "^4.7.5",
+        "socket.io-client": "^4.8.1",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -2835,13 +2836,6 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
     },
-    "node_modules/confbox": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
-      "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
-      "devOptional": true,
-      "license": "MIT"
-    },
     "node_modules/concat-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
@@ -2886,6 +2880,13 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "node_modules/confbox": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
+      "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/connect-sqlite3": {
       "version": "0.9.16",
@@ -3491,6 +3492,36 @@
       },
       "engines": {
         "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
+      "integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/engine.io-parser": {
@@ -7186,6 +7217,7 @@
           "optional": true
         }
       }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -7969,6 +8001,38 @@
         }
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
+      "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/socket.io-parser": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
@@ -8609,6 +8673,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -8622,11 +8692,6 @@
       "engines": {
         "node": ">=14.17"
       }
-    "node_modules/typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-      "license": "MIT"
     },
     "node_modules/uid-safe": {
       "version": "2.1.5",
@@ -8888,6 +8953,14 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -37,12 +37,13 @@
     "ioredis": "^5.4.1",
     "joi": "^17.12.0",
     "jsonwebtoken": "^9.0.2",
+    "multer": "^1.4.5-lts.2",
     "pg": "^8.11.5",
     "pg-hstore": "^2.3.4",
-    "multer": "^1.4.5-lts.2",
     "sanitize-html": "^2.13.0",
     "sequelize": "^6.37.3",
     "socket.io": "^4.7.5",
+    "socket.io-client": "^4.8.1",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/src/dining/availability.ts
+++ b/src/dining/availability.ts
@@ -1,0 +1,203 @@
+import { prisma } from './prismaClient.js';
+import type { DiningTable, Reservation } from '@prisma/client';
+import { listHoldsForSlot } from './holds.js';
+
+const DWELL_MINUTES = Number(process.env.DINING_DWELL_MINUTES ?? 105);
+
+export interface AvailabilityResult {
+  availableTableIds: string[];
+  suggestedCombos: string[][];
+}
+
+interface TableWithMeta extends DiningTable {
+  isAvailable: boolean;
+}
+
+function toDateInstance(value: string | Date): Date {
+  if (value instanceof Date) {
+    return new Date(value.getTime());
+  }
+  return new Date(`${value}T00:00:00`);
+}
+
+function combineDateTime(date: string | Date, time: string): Date {
+  const base = toDateInstance(date);
+  const [hourStr, minuteStr] = time.split(':');
+  const hour = Number.parseInt(hourStr ?? '0', 10);
+  const minute = Number.parseInt(minuteStr ?? '0', 10);
+  base.setHours(hour, minute, 0, 0);
+  return base;
+}
+
+export function overlaps(aStart: Date, aEnd: Date, bStart: Date, bEnd: Date): boolean {
+  return aStart < bEnd && bStart < aEnd;
+}
+
+function getReservationWindow(reservation: Reservation): { start: Date; end: Date } {
+  const start = combineDateTime(reservation.date, reservation.time);
+  const end = new Date(start.getTime() + DWELL_MINUTES * 60 * 1000);
+  return { start, end };
+}
+
+function getRequestedWindow(date: string, time: string): { start: Date; end: Date } {
+  const start = combineDateTime(date, time);
+  const end = new Date(start.getTime() + DWELL_MINUTES * 60 * 1000);
+  return { start, end };
+}
+
+function buildCombos(tables: DiningTable[], partySize: number): string[][] {
+  const combos: string[][] = [];
+  const available = tables
+    .filter((table) => table.capacity > 0)
+    .map((table) => ({
+      id: table.id,
+      capacity: table.capacity,
+      zone: table.zone ?? 'floor',
+      x: table.x,
+      y: table.y,
+    }));
+
+  available.sort((a, b) => a.capacity - b.capacity);
+
+  const maxComboSize = 3;
+
+  function isCompatibleZone(ids: number[]): boolean {
+    const zones = ids.map((index) => available[index].zone);
+    return zones.every((zone) => zone === zones[0]);
+  }
+
+  function distanceScore(indices: number[]): number {
+    if (indices.length <= 1) return 0;
+    let total = 0;
+    for (let i = 0; i < indices.length; i += 1) {
+      for (let j = i + 1; j < indices.length; j += 1) {
+        const a = available[indices[i]];
+        const b = available[indices[j]];
+        const dx = a.x - b.x;
+        const dy = a.y - b.y;
+        total += Math.sqrt(dx * dx + dy * dy);
+      }
+    }
+    return total;
+  }
+
+  function backtrack(startIndex: number, picked: number[], capacitySum: number): void {
+    if (capacitySum >= partySize && picked.length >= 2) {
+      combos.push(picked.map((index) => available[index].id));
+    }
+
+    if (picked.length === maxComboSize || capacitySum >= partySize * 2) {
+      return;
+    }
+
+    for (let i = startIndex; i < available.length; i += 1) {
+      if (picked.includes(i)) continue;
+      backtrack(i + 1, [...picked, i], capacitySum + available[i].capacity);
+    }
+  }
+
+  backtrack(0, [], 0);
+
+  const uniqueCombos = new Map<string, string[]>();
+  combos.forEach((combo) => {
+    const key = combo.slice().sort().join('|');
+    if (!uniqueCombos.has(key)) {
+      uniqueCombos.set(key, combo);
+    }
+  });
+
+  const scored = Array.from(uniqueCombos.values()).map((combo) => {
+    const indices = combo.map((id) => available.findIndex((item) => item.id === id));
+    const zoneBonus = isCompatibleZone(indices) ? 0 : 1;
+    const totalCapacity = combo.reduce((sum, id) => {
+      const table = available.find((item) => item.id === id);
+      return sum + (table?.capacity ?? 0);
+    }, 0);
+    const extraSeats = totalCapacity - partySize;
+    return {
+      combo,
+      score: zoneBonus * 1000 + extraSeats * 10 + distanceScore(indices),
+      tableCount: combo.length,
+      extraSeats,
+    };
+  });
+
+  scored.sort((a, b) => {
+    if (a.tableCount !== b.tableCount) return a.tableCount - b.tableCount;
+    if (a.extraSeats !== b.extraSeats) return a.extraSeats - b.extraSeats;
+    return a.score - b.score;
+  });
+
+  return scored.slice(0, 5).map((item) => item.combo);
+}
+
+export async function getDiningAvailability(
+  date: string,
+  time: string,
+  partySize: number,
+): Promise<AvailabilityResult> {
+  const tables = await prisma.diningTable.findMany({
+    where: { active: true },
+    orderBy: { label: 'asc' },
+  });
+
+  const { start: requestedStart, end: requestedEnd } = getRequestedWindow(date, time);
+
+  const startOfDay = new Date(requestedStart);
+  startOfDay.setHours(0, 0, 0, 0);
+  const endOfDay = new Date(requestedStart);
+  endOfDay.setHours(23, 59, 59, 999);
+
+  const reservations = await prisma.reservation.findMany({
+    where: {
+      status: { not: 'CANCELLED' },
+      date: {
+        gte: startOfDay,
+        lte: endOfDay,
+      },
+    },
+  });
+
+  const unavailableTableIds = new Set<string>();
+
+  reservations.forEach((reservation) => {
+    const { start, end } = getReservationWindow(reservation);
+    if (overlaps(requestedStart, requestedEnd, start, end)) {
+      reservation.tableIds.forEach((tableId) => {
+        unavailableTableIds.add(tableId);
+      });
+    }
+  });
+
+  const holds = await listHoldsForSlot(date, time);
+  holds.forEach((hold) => {
+    hold.tableIds.forEach((tableId) => {
+      unavailableTableIds.add(tableId);
+    });
+  });
+
+  const availableTables: TableWithMeta[] = tables.map((table) => ({
+    ...table,
+    isAvailable: !unavailableTableIds.has(table.id),
+  }));
+
+  const availableTableIds = availableTables
+    .filter((table) => table.isAvailable)
+    .map((table) => table.id);
+
+  const suggestedCombos: string[][] = [];
+
+  const maxSingleCapacity = availableTables
+    .filter((table) => table.isAvailable)
+    .reduce((max, table) => Math.max(max, table.capacity), 0);
+
+  if (partySize > maxSingleCapacity) {
+    suggestedCombos.push(...buildCombos(availableTables.filter((table) => table.isAvailable), partySize));
+  }
+
+  return {
+    availableTableIds,
+    suggestedCombos,
+  };
+}
+

--- a/src/dining/client/SeatMap.tsx
+++ b/src/dining/client/SeatMap.tsx
@@ -1,0 +1,295 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { Socket } from 'socket.io-client';
+import { io } from 'socket.io-client';
+
+type DiningTable = {
+  id: string;
+  label: string;
+  capacity: number;
+  x: number;
+  y: number;
+  rotation?: number | null;
+  zone?: string | null;
+};
+
+type HoldInfo = {
+  holdId: string;
+  expiresAt: number;
+};
+
+type SeatUpdateEvent = {
+  date: string;
+  time: string;
+  tableIds: string[];
+  status: 'held' | 'available';
+  holdId?: string;
+  expiresAt?: number;
+  reason: 'hold.created' | 'hold.released' | 'hold.extended' | 'hold.expired';
+};
+
+type InitialAvailability = {
+  availableTableIds: string[];
+};
+
+export interface SeatMapProps {
+  tables: DiningTable[];
+  date: string;
+  time: string;
+  initialAvailability: InitialAvailability;
+  onSelect(tableIds: string[]): void;
+}
+
+type TableStatus = 'available' | 'selected' | 'held' | 'unavailable';
+
+const TABLE_WIDTH = 36;
+const TABLE_HEIGHT = 24;
+const SOCKET_PATH = '/ws/dining';
+
+function formatCountdown(seconds: number): string {
+  const clamped = Math.max(0, seconds);
+  const minutes = Math.floor(clamped / 60);
+  const remainingSeconds = clamped % 60;
+  return `${minutes}:${remainingSeconds.toString().padStart(2, '0')}`;
+}
+
+export function SeatMap({ tables, date, time, initialAvailability, onSelect }: SeatMapProps): JSX.Element {
+  const [selected, setSelected] = useState<string[]>([]);
+  const [heldTables, setHeldTables] = useState<Map<string, HoldInfo>>(() => new Map());
+  const [now, setNow] = useState(() => Date.now());
+  const socketRef = useRef<Socket | null>(null);
+
+  const [availableTables, setAvailableTables] = useState<Set<string>>(
+    () => new Set(initialAvailability.availableTableIds),
+  );
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setNow(Date.now());
+    }, 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  const sortedTables = useMemo(() => {
+    return [...tables].sort((a, b) => {
+      if (a.y === b.y) {
+        return a.x - b.x;
+      }
+      return a.y - b.y;
+    });
+  }, [tables]);
+
+  const tableRefs = useRef<Record<string, SVGGElement | null>>({});
+
+  const updateSelection = useCallback(
+    (updater: (current: string[]) => string[] | null) => {
+      setSelected((current) => {
+        const next = updater(current);
+        if (next === null) {
+          return current;
+        }
+        if (next.length === current.length && next.every((value, index) => value === current[index])) {
+          return current;
+        }
+        onSelect(next);
+        return next;
+      });
+    },
+    [onSelect],
+  );
+
+  const toggleTable = useCallback(
+    (tableId: string) => {
+      updateSelection((current) => {
+        if (current.includes(tableId)) {
+          return current.filter((id) => id !== tableId);
+        }
+
+        if (heldTables.has(tableId) || !availableTables.has(tableId)) {
+          return null;
+        }
+
+        return [...current, tableId];
+      });
+    },
+    [availableTables, heldTables, updateSelection],
+  );
+
+  const handleSeatUpdate = useCallback(
+    (payload: SeatUpdateEvent) => {
+      if (payload.date !== date || payload.time !== time) {
+        return;
+      }
+
+      setHeldTables((current) => {
+        const next = new Map(current);
+        if (payload.status === 'available') {
+          payload.tableIds.forEach((tableId) => {
+            next.delete(tableId);
+          });
+        } else if (payload.status === 'held' && payload.holdId && payload.expiresAt) {
+          payload.tableIds.forEach((tableId) => {
+            next.set(tableId, { holdId: payload.holdId!, expiresAt: payload.expiresAt! });
+          });
+        }
+        return next;
+      });
+
+      setAvailableTables((current) => {
+        const next = new Set(current);
+        if (payload.status === 'available') {
+          payload.tableIds.forEach((id) => next.add(id));
+        }
+        if (payload.status === 'held') {
+          payload.tableIds.forEach((id) => next.delete(id));
+        }
+        return next;
+      });
+
+      if (payload.status === 'held') {
+        updateSelection((current) => {
+          const filtered = current.filter((id) => !payload.tableIds.includes(id));
+          return filtered;
+        });
+      }
+    },
+    [date, time, updateSelection],
+  );
+
+  useEffect(() => {
+    const socket = io({ path: SOCKET_PATH, transports: ['websocket', 'polling'] });
+    socketRef.current = socket;
+    socket.on('seatUpdate', handleSeatUpdate);
+    return () => {
+      socket.off('seatUpdate', handleSeatUpdate);
+      socket.disconnect();
+      socketRef.current = null;
+    };
+  }, [handleSeatUpdate]);
+
+  const getStatus = useCallback(
+    (tableId: string): TableStatus => {
+      if (selected.includes(tableId)) {
+        return 'selected';
+      }
+      if (heldTables.has(tableId)) {
+        return 'held';
+      }
+      if (!availableTables.has(tableId)) {
+        return 'unavailable';
+      }
+      return 'available';
+    },
+    [availableTables, heldTables, selected],
+  );
+
+  const focusNeighbor = useCallback(
+    (currentId: string, direction: 'next' | 'prev') => {
+      const currentIndex = sortedTables.findIndex((table) => table.id === currentId);
+      if (currentIndex === -1) return;
+      const nextIndex = direction === 'next' ? currentIndex + 1 : currentIndex - 1;
+      const target = sortedTables[nextIndex];
+      if (!target) return;
+      const node = tableRefs.current[target.id];
+      node?.focus();
+    },
+    [sortedTables],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<SVGGElement>, tableId: string) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        toggleTable(tableId);
+        return;
+      }
+      if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+        event.preventDefault();
+        focusNeighbor(tableId, 'next');
+        return;
+      }
+      if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+        event.preventDefault();
+        focusNeighbor(tableId, 'prev');
+      }
+    },
+    [focusNeighbor, toggleTable],
+  );
+
+  const bounds = useMemo(() => {
+    const xs = tables.map((table) => table.x);
+    const ys = tables.map((table) => table.y);
+    const maxX = Math.max(...xs, 0) + TABLE_WIDTH + 20;
+    const maxY = Math.max(...ys, 0) + TABLE_HEIGHT + 20;
+    return {
+      width: Math.max(maxX, 320),
+      height: Math.max(maxY, 240),
+    };
+  }, [tables]);
+
+  const renderTable = useCallback(
+    (table: DiningTable) => {
+      const status = getStatus(table.id);
+      const hold = heldTables.get(table.id);
+      const countdown = hold ? Math.round((hold.expiresAt - now) / 1000) : null;
+      const rotation = table.rotation ?? 0;
+      const transform = `translate(${table.x}, ${table.y}) rotate(${rotation}, ${TABLE_WIDTH / 2}, ${TABLE_HEIGHT / 2})`;
+      const isInteractive = status === 'available' || status === 'selected';
+      const zoneClass = table.zone ? `zone-${table.zone.toLowerCase().replace(/\s+/g, '-')}` : 'zone-default';
+
+      let fill = '#0f766e';
+      if (status === 'selected') fill = '#1d4ed8';
+      if (status === 'held') fill = '#b45309';
+      if (status === 'unavailable') fill = '#4b5563';
+
+      const textColor = status === 'held' || status === 'unavailable' ? '#f9fafb' : '#0f172a';
+
+      return (
+        <g
+          key={table.id}
+          ref={(node) => {
+            tableRefs.current[table.id] = node;
+          }}
+          role="button"
+          tabIndex={0}
+          aria-pressed={status === 'selected'}
+          aria-disabled={!isInteractive}
+          data-status={status}
+          data-table-id={table.id}
+          className={`seat ${zoneClass} status-${status}`}
+          transform={transform}
+          onClick={() => isInteractive && toggleTable(table.id)}
+          onKeyDown={(event) => handleKeyDown(event, table.id)}
+        >
+          <rect width={TABLE_WIDTH} height={TABLE_HEIGHT} rx={6} ry={6} fill={fill} stroke="#0f172a" strokeWidth={1.5} />
+          <text
+            x={TABLE_WIDTH / 2}
+            y={TABLE_HEIGHT / 2}
+            dominantBaseline="middle"
+            textAnchor="middle"
+            fontSize={10}
+            fill={textColor}
+            pointerEvents="none"
+          >
+            {table.label}
+          </text>
+          <text x={TABLE_WIDTH / 2} y={TABLE_HEIGHT - 4} dominantBaseline="ideographic" textAnchor="middle" fontSize={8} fill={textColor} pointerEvents="none">
+            {status === 'held' && countdown !== null ? `Hold ${formatCountdown(countdown)}` : `Seats ${table.capacity}`}
+          </text>
+        </g>
+      );
+    },
+    [getStatus, handleKeyDown, heldTables, now, toggleTable],
+  );
+
+  return (
+    <div className="seat-map" role="presentation">
+      <svg width="100%" height="100%" viewBox={`0 0 ${bounds.width} ${bounds.height}`} aria-label="Dining room seat map">
+        <rect x={0} y={0} width={bounds.width} height={bounds.height} fill="#f1f5f9" rx={12} />
+        {tables.map(renderTable)}
+      </svg>
+    </div>
+  );
+}
+
+export default SeatMap;
+

--- a/src/dining/holds.ts
+++ b/src/dining/holds.ts
@@ -1,0 +1,379 @@
+import crypto from 'node:crypto';
+import { EventEmitter } from 'node:events';
+import type Redis from 'ioredis';
+import { getRedis } from '../db/redis.js';
+
+export interface HoldRecord {
+  holdId: string;
+  userId: string;
+  date: string; // YYYY-MM-DD
+  time: string; // HH:mm
+  tableIds: string[];
+  expiresAt: number; // epoch ms
+}
+
+const HOLD_TTL_SECONDS = Number(process.env.DINING_HOLD_TTL ?? 180);
+
+type HoldKey = string;
+
+const localHolds = new Map<HoldKey, HoldRecord>();
+const holdIdToKey = new Map<string, HoldKey>();
+const expiryTimers = new Map<string, NodeJS.Timeout>();
+
+type HoldEventMap = {
+  'hold.created': (hold: HoldRecord) => void;
+  'hold.released': (hold: HoldRecord) => void;
+  'hold.extended': (hold: HoldRecord) => void;
+  'hold.expired': (hold: HoldRecord) => void;
+};
+
+export const holdEvents = new EventEmitter<HoldEventMap>();
+
+function buildHoldKey(date: string, time: string, tableIds: string[]): HoldKey {
+  const normalizedIds = [...tableIds].sort();
+  return `hold:${date}:${time}:${normalizedIds.join(',')}`;
+}
+
+function buildIndexKey(date: string, time: string): string {
+  return `hold:index:${date}:${time}`;
+}
+
+function buildLookupKey(holdId: string): string {
+  return `holdById:${holdId}`;
+}
+
+async function ensureRedisConnected(client: Redis | undefined | null): Promise<boolean> {
+  if (!client || typeof client.connect !== 'function') {
+    return false;
+  }
+  if ((client as any).status === 'ready' || (client as any).status === 'connecting') {
+    return true;
+  }
+  try {
+    await client.connect();
+    return true;
+  } catch (error) {
+    console.warn('Redis connection failed for dining holds. Falling back to memory.', (error as Error).message);
+    return false;
+  }
+}
+
+function purgeExpiredLocalHolds(): void {
+  const now = Date.now();
+  for (const [key, hold] of localHolds.entries()) {
+    if (hold.expiresAt <= now) {
+      localHolds.delete(key);
+      holdIdToKey.delete(hold.holdId);
+    }
+  }
+}
+
+async function storeHoldInRedis(
+  redis: Redis,
+  hold: HoldRecord,
+  ttlSeconds: number,
+  holdKey: HoldKey,
+): Promise<boolean> {
+  const indexKey = buildIndexKey(hold.date, hold.time);
+  const lookupKey = buildLookupKey(hold.holdId);
+  const payload = JSON.stringify(hold);
+
+  const setResult = await redis.set(holdKey, payload, 'EX', ttlSeconds, 'NX');
+  if (setResult !== 'OK') {
+    return false;
+  }
+
+  await redis.multi()
+    .set(lookupKey, holdKey, 'EX', ttlSeconds)
+    .sadd(indexKey, holdKey)
+    .expire(indexKey, Math.max(ttlSeconds, HOLD_TTL_SECONDS))
+    .exec();
+
+  return true;
+}
+
+function storeHoldLocally(hold: HoldRecord, holdKey: HoldKey): void {
+  purgeExpiredLocalHolds();
+  localHolds.set(holdKey, hold);
+  holdIdToKey.set(hold.holdId, holdKey);
+}
+
+function clearExpiryTimer(holdId: string): void {
+  const timer = expiryTimers.get(holdId);
+  if (timer) {
+    clearTimeout(timer);
+    expiryTimers.delete(holdId);
+  }
+}
+
+function scheduleExpiry(hold: HoldRecord): void {
+  clearExpiryTimer(hold.holdId);
+  const delay = hold.expiresAt - Date.now();
+  if (delay <= 0) {
+    holdEvents.emit('hold.expired', hold);
+    return;
+  }
+  const timer = setTimeout(() => {
+    expiryTimers.delete(hold.holdId);
+    const holdKey = holdIdToKey.get(hold.holdId);
+    if (holdKey) {
+      localHolds.delete(holdKey);
+      holdIdToKey.delete(hold.holdId);
+    }
+    holdEvents.emit('hold.expired', hold);
+  }, delay);
+  if (typeof timer.unref === 'function') {
+    timer.unref();
+  }
+  expiryTimers.set(hold.holdId, timer);
+}
+
+export async function createHold(
+  params: {
+    date: string;
+    time: string;
+    tableIds: string[];
+    userId: string;
+    ttlSeconds?: number;
+  },
+): Promise<{ hold: HoldRecord } | { error: string }> {
+  const { date, time, tableIds, userId } = params;
+  const ttlSeconds = params.ttlSeconds ?? HOLD_TTL_SECONDS;
+
+  if (!date || !time || !Array.isArray(tableIds) || tableIds.length === 0) {
+    return { error: 'Invalid hold parameters' };
+  }
+
+  const holdKey = buildHoldKey(date, time, tableIds);
+  const redis = getRedis() as Redis | undefined;
+  const redisReady = await ensureRedisConnected(redis);
+
+  const now = Date.now();
+  const existingHold = redisReady
+    ? await redis!.get(holdKey)
+    : undefined;
+  if (existingHold) {
+    return { error: 'Tables already held' };
+  }
+
+  purgeExpiredLocalHolds();
+  const localExisting = localHolds.get(holdKey);
+  if (localExisting && localExisting.expiresAt > now) {
+    return { error: 'Tables already held' };
+  }
+
+  const hold: HoldRecord = {
+    holdId: crypto.randomUUID(),
+    userId,
+    date,
+    time,
+    tableIds: [...tableIds].sort(),
+    expiresAt: now + ttlSeconds * 1000,
+  };
+
+  if (redisReady && redis) {
+    const stored = await storeHoldInRedis(redis, hold, ttlSeconds, holdKey);
+    if (!stored) {
+      console.warn('Failed to persist hold to Redis, using in-memory store.');
+    } else {
+      storeHoldLocally(hold, holdKey);
+      scheduleExpiry(hold);
+      holdEvents.emit('hold.created', hold);
+      return { hold };
+    }
+  }
+
+  storeHoldLocally(hold, holdKey);
+  scheduleExpiry(hold);
+  holdEvents.emit('hold.created', hold);
+  return { hold };
+}
+
+export async function releaseHold(holdId: string): Promise<boolean> {
+  purgeExpiredLocalHolds();
+  const localKey = holdIdToKey.get(holdId);
+  const existing = localKey ? localHolds.get(localKey) : undefined;
+  if (localKey) {
+    localHolds.delete(localKey);
+    holdIdToKey.delete(holdId);
+  }
+  if (existing) {
+    clearExpiryTimer(existing.holdId);
+  }
+
+  const redis = getRedis() as Redis | undefined;
+  const redisReady = await ensureRedisConnected(redis);
+  let holdForEvent = existing;
+  let released = Boolean(localKey);
+  if (redisReady && redis) {
+    const lookupKey = buildLookupKey(holdId);
+    const holdKey = await redis.get(lookupKey);
+    if (holdKey) {
+      const parsed = localHolds.get(holdKey);
+      if (parsed) {
+        localHolds.delete(holdKey);
+        holdIdToKey.delete(parsed.holdId);
+        clearExpiryTimer(parsed.holdId);
+      }
+
+      let payload: string | null = null;
+      const parts = holdKey.split(':');
+      if (parts.length >= 4) {
+        const date = parts[1];
+        const time = parts[2];
+        const indexKey = buildIndexKey(date, time);
+        payload = await redis.get(holdKey);
+        await redis.multi().del(holdKey, lookupKey).srem(indexKey, holdKey).exec();
+        released = true;
+      } else {
+        payload = await redis.get(holdKey);
+        await redis.del(holdKey);
+        await redis.del(lookupKey);
+        released = true;
+      }
+
+      if (payload) {
+        try {
+          holdForEvent = JSON.parse(payload) as HoldRecord;
+        } catch (error) {
+          console.warn('Failed to parse hold payload during release', error);
+        }
+      }
+    }
+  }
+  if (holdForEvent) {
+    holdEvents.emit('hold.released', holdForEvent);
+  }
+  return released;
+}
+
+export async function extendHold(holdId: string, ttlSeconds?: number): Promise<HoldRecord | undefined> {
+  purgeExpiredLocalHolds();
+  const ttl = ttlSeconds ?? HOLD_TTL_SECONDS;
+  const redis = getRedis() as Redis | undefined;
+  const redisReady = await ensureRedisConnected(redis);
+
+  const now = Date.now();
+  const localKey = holdIdToKey.get(holdId);
+  let updated: HoldRecord | undefined;
+  if (localKey) {
+    const record = localHolds.get(localKey);
+    if (record) {
+      record.expiresAt = now + ttl * 1000;
+      localHolds.set(localKey, record);
+      updated = record;
+      scheduleExpiry(record);
+    }
+  }
+
+  if (redisReady && redis) {
+    const lookupKey = buildLookupKey(holdId);
+    const holdKey = await redis.get(lookupKey);
+    if (!holdKey) {
+      return updated;
+    }
+    const holdRaw = await redis.get(holdKey);
+    if (!holdRaw) {
+      return updated;
+    }
+    const hold = JSON.parse(holdRaw) as HoldRecord;
+    hold.expiresAt = now + ttl * 1000;
+    await storeHoldInRedis(redis, hold, ttl, holdKey);
+    storeHoldLocally(hold, holdKey);
+    scheduleExpiry(hold);
+    holdEvents.emit('hold.extended', hold);
+    return hold;
+  }
+
+  if (updated) {
+    holdEvents.emit('hold.extended', updated);
+  }
+  return updated;
+}
+
+export async function listHoldsForSlot(date: string, time: string): Promise<HoldRecord[]> {
+  purgeExpiredLocalHolds();
+  const redis = getRedis() as Redis | undefined;
+  const redisReady = await ensureRedisConnected(redis);
+
+  const holds: HoldRecord[] = [];
+
+  if (redisReady && redis) {
+    const indexKey = buildIndexKey(date, time);
+    const holdKeys = await redis.smembers(indexKey);
+    if (holdKeys.length > 0) {
+      const pipeline = (redis as unknown as Redis & { mget: Redis['mget'] });
+      const values = await pipeline.mget(holdKeys);
+      for (let i = 0; i < holdKeys.length; i += 1) {
+        const value = values[i];
+        if (!value) {
+          continue;
+        }
+        try {
+          const record = JSON.parse(value) as HoldRecord;
+          if (record.expiresAt > Date.now()) {
+            holds.push(record);
+            storeHoldLocally(record, holdKeys[i]);
+            scheduleExpiry(record);
+          }
+        } catch (error) {
+          console.warn('Failed to parse hold payload', error);
+        }
+      }
+    }
+  }
+
+  for (const [key, hold] of localHolds.entries()) {
+    if (hold.date === date && hold.time === time && hold.expiresAt > Date.now()) {
+      if (!holds.some((existing) => existing.holdId === hold.holdId)) {
+        holds.push(hold);
+        storeHoldLocally(hold, key);
+        scheduleExpiry(hold);
+      }
+    }
+  }
+
+  return holds;
+}
+
+export function getHoldLocally(holdId: string): HoldRecord | undefined {
+  purgeExpiredLocalHolds();
+  const key = holdIdToKey.get(holdId);
+  if (!key) {
+    return undefined;
+  }
+  return localHolds.get(key);
+}
+
+export async function getHoldById(holdId: string): Promise<HoldRecord | undefined> {
+  const local = getHoldLocally(holdId);
+  if (local) {
+    return local;
+  }
+
+  const redis = getRedis() as Redis | undefined;
+  const redisReady = await ensureRedisConnected(redis);
+  if (!redisReady || !redis) {
+    return undefined;
+  }
+
+  const lookupKey = buildLookupKey(holdId);
+  const holdKey = await redis.get(lookupKey);
+  if (!holdKey) {
+    return undefined;
+  }
+  const payload = await redis.get(holdKey);
+  if (!payload) {
+    return undefined;
+  }
+  try {
+    const record = JSON.parse(payload) as HoldRecord;
+    storeHoldLocally(record, holdKey);
+    scheduleExpiry(record);
+    return record;
+  } catch (error) {
+    console.warn('Failed to parse hold payload for lookup', error);
+    return undefined;
+  }
+}
+

--- a/src/dining/realtime.ts
+++ b/src/dining/realtime.ts
@@ -1,0 +1,84 @@
+import { Server as HTTPServer } from 'node:http';
+import { Server as SocketIOServer, type Socket } from 'socket.io';
+import type { HoldRecord } from './holds.js';
+import { holdEvents } from './holds.js';
+
+type SeatUpdatePayload = {
+  date: string;
+  time: string;
+  tableIds: string[];
+  status: 'held' | 'available';
+  holdId?: string;
+  expiresAt?: number;
+  reason: 'hold.created' | 'hold.released' | 'hold.extended' | 'hold.expired';
+};
+
+let ioInstance: SocketIOServer | null = null;
+
+function emitSeatUpdate(hold: HoldRecord, status: SeatUpdatePayload['status'], reason: SeatUpdatePayload['reason']): void {
+  if (!ioInstance) return;
+  const payload: SeatUpdatePayload = {
+    date: hold.date,
+    time: hold.time,
+    tableIds: hold.tableIds,
+    status,
+    holdId: hold.holdId,
+    expiresAt: hold.expiresAt,
+    reason,
+  };
+
+  if (status === 'available') {
+    delete payload.expiresAt;
+  }
+
+  ioInstance.emit('seatUpdate', payload);
+}
+
+function bindHoldEvents(): void {
+  holdEvents.on('hold.created', (hold) => {
+    emitSeatUpdate(hold, 'held', 'hold.created');
+  });
+  holdEvents.on('hold.extended', (hold) => {
+    emitSeatUpdate(hold, 'held', 'hold.extended');
+  });
+  holdEvents.on('hold.released', (hold) => {
+    emitSeatUpdate(hold, 'available', 'hold.released');
+  });
+  holdEvents.on('hold.expired', (hold) => {
+    emitSeatUpdate(hold, 'available', 'hold.expired');
+  });
+}
+
+let eventsBound = false;
+
+export function attachDiningRealtime(server: HTTPServer): SocketIOServer {
+  if (ioInstance) {
+    return ioInstance;
+  }
+
+  const io = new SocketIOServer(server, {
+    path: '/ws/dining',
+    cors: {
+      origin: process.env.SOCKET_ORIGIN ?? '*',
+      credentials: true,
+    },
+  });
+
+  io.on('connection', (socket: Socket) => {
+    socket.emit('welcome', { message: 'connected' });
+  });
+
+  ioInstance = io;
+
+  if (!eventsBound) {
+    bindHoldEvents();
+    eventsBound = true;
+  }
+
+  return io;
+}
+
+export function getDiningSocket(): SocketIOServer | null {
+  return ioInstance;
+}
+

--- a/src/dining/server.ts
+++ b/src/dining/server.ts
@@ -1,8 +1,12 @@
 import express, { type Request, type Response } from 'express';
 import type { Reservation } from '@prisma/client';
 import { fileURLToPath } from 'url';
+import { createServer } from 'node:http';
 import { prisma } from './prismaClient.js';
 import { verifySession } from '../auth/verifySession.js';
+import { getDiningAvailability } from './availability.js';
+import { createHold, releaseHold, getHoldById, extendHold } from './holds.js';
+import { attachDiningRealtime } from './realtime.js';
 
 const app = express();
 
@@ -44,6 +48,109 @@ app.get('/api/dining/tables', async (_req: Request, res: Response) => {
   }
 });
 
+app.get('/api/dining/availability', async (req: Request, res: Response) => {
+  try {
+    const { date, time, partySize } = req.query;
+
+    if (typeof date !== 'string' || typeof time !== 'string' || typeof partySize !== 'string') {
+      res.status(400).json({ error: 'Missing or invalid parameters' });
+      return;
+    }
+
+    const parsedPartySize = Number.parseInt(partySize, 10);
+    if (Number.isNaN(parsedPartySize) || parsedPartySize <= 0) {
+      res.status(400).json({ error: 'partySize must be a positive integer' });
+      return;
+    }
+
+    const availability = await getDiningAvailability(date, time, parsedPartySize);
+    res.json(availability);
+  } catch (error) {
+    console.error('Failed to compute dining availability', error);
+    res.status(500).json({ error: 'Failed to compute dining availability' });
+  }
+});
+
+app.post('/api/dining/hold', verifySession, async (req: Request, res: Response) => {
+  try {
+    if (!req.user) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+
+    const { date, time, tableIds } = req.body ?? {};
+    if (typeof date !== 'string' || typeof time !== 'string' || !Array.isArray(tableIds) || tableIds.length === 0) {
+      res.status(400).json({ error: 'Invalid hold payload' });
+      return;
+    }
+
+    const availability = await getDiningAvailability(date, time, 1);
+    const unavailable = tableIds.filter((id: string) => !availability.availableTableIds.includes(id));
+    if (unavailable.length > 0) {
+      res.status(409).json({ error: 'Some tables are no longer available', tables: unavailable });
+      return;
+    }
+
+    const result = await createHold({ date, time, tableIds, userId: req.user.id });
+    if ('error' in result) {
+      res.status(409).json({ error: result.error });
+      return;
+    }
+
+    res.status(201).json({ holdId: result.hold.holdId, expiresAt: result.hold.expiresAt });
+  } catch (error) {
+    console.error('Failed to create dining hold', error);
+    res.status(500).json({ error: 'Failed to create hold' });
+  }
+});
+
+app.post('/api/dining/release', verifySession, async (req: Request, res: Response) => {
+  try {
+    if (!req.user) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+
+    const { holdId, extend } = req.body ?? {};
+    if (typeof holdId !== 'string') {
+      res.status(400).json({ error: 'holdId is required' });
+      return;
+    }
+
+    const hold = await getHoldById(holdId);
+    if (!hold) {
+      res.status(404).json({ error: 'Hold not found' });
+      return;
+    }
+
+    if (hold.userId !== req.user.id) {
+      res.status(403).json({ error: 'Cannot modify another user\'s hold' });
+      return;
+    }
+
+    if (extend === true) {
+      const extended = await extendHold(holdId);
+      if (!extended) {
+        res.status(500).json({ error: 'Failed to extend hold' });
+        return;
+      }
+      res.json({ holdId, expiresAt: extended.expiresAt });
+      return;
+    }
+
+    const released = await releaseHold(holdId);
+    if (!released) {
+      res.status(500).json({ error: 'Failed to release hold' });
+      return;
+    }
+
+    res.json({ released: true });
+  } catch (error) {
+    console.error('Failed to release dining hold', error);
+    res.status(500).json({ error: 'Failed to release hold' });
+  }
+});
+
 app.get('/api/dining/reservations/me', verifySession, async (req: Request, res: Response) => {
   if (!req.user) {
     res.status(401).json({ error: 'Unauthorized' });
@@ -70,7 +177,9 @@ export { app };
 if (process.argv[1]) {
   const isMainModule = process.argv[1] === fileURLToPath(import.meta.url);
   if (isMainModule) {
-    app.listen(PORT, () => {
+    const server = createServer(app);
+    attachDiningRealtime(server);
+    server.listen(PORT, () => {
       console.log(`Dining API server listening on port ${PORT}`);
     });
   }


### PR DESCRIPTION
## Summary
- add a Redis-backed hold manager that tracks expiry timers and emits events for create, extend, release, and expire flows
- surface dining availability and hold APIs while wiring Socket.IO broadcasting for seat updates
- build a React SVG seat map that listens to live hold updates and supports keyboard selection

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ec6ce2f6d083239af35809d8d37853