### PR TITLE
Correct GSAP CDN integrity hash

### DIFF
--- a/public/css/dining.css
+++ b/public/css/dining.css
@@ -12,7 +12,7 @@
   font-family: 'Outfit', sans-serif;
 }
 
-[data-theme="dining"] a {
+[data-theme="dining"] a:not(.btn) {
   color: var(--dining-accent);
 }
 
@@ -37,14 +37,30 @@
   margin-bottom: 4rem;
 }
 
+.dining-hero__copy {
+  max-width: 540px;
+  margin-inline: auto;
+}
+
 .dining-hero__copy h1 {
   font-size: clamp(2.8rem, 5vw, 4rem);
   margin-bottom: 1rem;
 }
 
+.dining-hero__copy p {
+  margin-bottom: 1.75rem;
+  line-height: 1.7;
+}
+
 .dining-hero__copy .cta-group {
   display: flex;
   gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.dining-hero__copy .cta-group .btn {
+  flex: 1 1 200px;
+  justify-content: center;
 }
 
 .dining-hero__media {
@@ -136,11 +152,26 @@
 .btn-outline {
   border: 1px solid rgba(207, 168, 88, 0.45);
   color: var(--dining-accent);
-  background: transparent;
+  background: rgba(5, 7, 15, 0.55);
+  box-shadow: inset 0 0 0 1px rgba(207, 168, 88, 0.1);
 }
 
 .btn:hover {
   transform: translateY(-2px);
+}
+
+@media (max-width: 720px) {
+  .dining-hero {
+    text-align: center;
+  }
+
+  .dining-hero__copy {
+    margin-inline: 0;
+  }
+
+  .dining-hero__copy .cta-group {
+    justify-content: center;
+  }
 }
 
 .menu-header {

--- a/views/partials/head.ejs
+++ b/views/partials/head.ejs
@@ -15,7 +15,7 @@
   <link rel="mask-icon" href="/icons/aurora-icon-maskable.svg" color="#0ea5e9" />
   <link rel="apple-touch-icon" type="image/svg+xml" sizes="192x192" href="/icons/aurora-icon-192.svg" />
   <meta name="csrf-token" content="<%= csrfToken %>" />
-  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" integrity="sha512-Nd3XoqBYwygJyI072QtdgQXl3k5ufADG7n2AFD+a83H8XTur2qxGn8pY/+bexdFv+DE5jBqFaUG2RgxN+E466Q==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" integrity="sha512-7eHRwcbYkK4d9g/6tD/mhkf++eoTHwpNM9woBxtPUBWm67zeAfFC+HrdoE2GanKeocly/VxeLvIqwvCdk7qScg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script defer src="/socket.io/socket.io.js"></script>
   <script defer src="/js/main.js"></script>
 </head>


### PR DESCRIPTION
## Summary
- update the GSAP CDN script tag to use the correct 3.12.5 integrity hash so the library loads on dining

## Testing
- npm run hotel:start *(fails: Cannot find module 'jsonwebtoken')*

------
https://chatgpt.com/codex/tasks/task_e_68ec7230ecf08323be1570fc0f6f5774