### PR TITLE
Add dining admin API endpoints and config storage

### DIFF
--- a/prisma/migrations/0002_dining_config/migration.sql
+++ b/prisma/migrations/0002_dining_config/migration.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "DiningConfig" (
+    "id" TEXT NOT NULL,
+    "dwellMinutes" INTEGER NOT NULL DEFAULT 120,
+    "blackoutDates" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "policyText" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "DiningConfig_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,3 +76,12 @@ model Staff {
   photoUrl String?
   active   Boolean @default(true)
 }
+
+model DiningConfig {
+  id            String   @id @default("default")
+  dwellMinutes  Int      @default(120)
+  blackoutDates String[] @default([])
+  policyText    String?
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+}

--- a/src/dining/requireAdmin.ts
+++ b/src/dining/requireAdmin.ts
@@ -1,0 +1,38 @@
+import type { NextFunction, Request, Response } from 'express';
+
+function parseAllowlist(): Set<string> {
+  const raw = process.env.ADMIN_EMAILS ?? '';
+  return new Set(
+    raw
+      .split(',')
+      .map((value) => value.trim().toLowerCase())
+      .filter((value) => value.length > 0),
+  );
+}
+
+function isEmailAllowed(email: string | null | undefined): boolean {
+  if (!email) {
+    return false;
+  }
+  const allowlist = parseAllowlist();
+  if (allowlist.size === 0) {
+    return false;
+  }
+  return allowlist.has(email.trim().toLowerCase());
+}
+
+export function requireAdmin(req: Request, res: Response, next: NextFunction): void {
+  if (!req.user) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+  if (!isEmailAllowed(req.user.email)) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  next();
+}
+
+export function isAdminEmail(email: string | null | undefined): boolean {
+  return isEmailAllowed(email);
+}


### PR DESCRIPTION
## Summary
- add ADMIN_EMAILS allowlist middleware and gate all dining admin APIs behind it
- implement reservations filtering, CSV export, table management, menu CRUD, and configuration endpoints for dining admin portal
- introduce dining configuration persistence via new Prisma table and migration

## Testing
- npm test *(fails: Cannot find module 'jsonwebtoken' from 'src/utils/jwt.js')*

------
https://chatgpt.com/codex/tasks/task_e_68ec744f9a8c8323b9a5a813a7c86f44