### PR TITLE
Allow dining pages to respect session logins

### DIFF
--- a/src/utils/jwt.js
+++ b/src/utils/jwt.js
@@ -36,20 +36,37 @@ function verifyHotelToken(token) {
   }
 }
 
+function formatUserLike(userLike) {
+  if (!userLike) return null;
+  const { id, email, name, role } = userLike;
+  if (!id) {
+    return null;
+  }
+  return {
+    id,
+    email: email || null,
+    name: name || null,
+    role: role || 'guest'
+  };
+}
+
 function getUserFromRequest(req) {
+  if (req?.user) {
+    const normalized = formatUserLike(req.user);
+    if (normalized) {
+      return normalized;
+    }
+  }
+
   const token = getSessionToken(req);
   const payload = verifyHotelToken(token);
   if (!payload) return null;
   if (payload.user) {
-    return payload.user;
+    const normalized = formatUserLike(payload.user);
+    return normalized;
   }
   const { sub, email, name, role } = payload;
-  return {
-    id: sub,
-    email,
-    name,
-    role: role || 'guest'
-  };
+  return formatUserLike({ id: sub, email, name, role });
 }
 
 function ensureDiningAuthenticated(req, res, next) {


### PR DESCRIPTION
## Summary
- normalize request-derived user data so dining routes accept express-session logins
- ensure dining locals reuse the normalized user object when present

## Testing
- npm test --silent *(fails: Cannot find module 'jsonwebtoken' from 'src/utils/jwt.js')*

------
https://chatgpt.com/codex/tasks/task_e_68ec763aa62c8323ab384acf9a9c7e32