### PR TITLE
Ensure admin content renders without animations

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -2014,13 +2014,19 @@ tr.is-low .inventory-pill {
   }
 }
 
+/* Ensure animated sections stay visible when JavaScript is unavailable */
 [data-animate] {
+  opacity: 1;
+  transform: none;
+}
+
+html[data-animations='enabled'] [data-animate] {
   opacity: 0;
   transform: translateY(24px);
   transition: opacity 0.8s ease, transform 0.8s ease;
 }
 
-[data-animate].is-visible {
+html[data-animations='enabled'] [data-animate].is-visible {
   opacity: 1;
   transform: translateY(0);
 }

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -2,6 +2,7 @@
 (() => {
   const root = document.documentElement;
   const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content');
+  root?.setAttribute('data-animations', 'enabled');
   if (csrfToken) {
     window.__CSRF_TOKEN__ = csrfToken;
   }
@@ -80,21 +81,28 @@
     });
   }
 
-  const observer = new IntersectionObserver(
-    (entries) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          entry.target.classList.add('is-visible');
-          observer.unobserve(entry.target);
-        }
-      });
-    },
-    { threshold: 0.2 }
-  );
+  const animatedElements = document.querySelectorAll('[data-animate]');
+  if ('IntersectionObserver' in window) {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('is-visible');
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.2 }
+    );
 
-  document.querySelectorAll('[data-animate]').forEach((element) => {
-    observer.observe(element);
-  });
+    animatedElements.forEach((element) => {
+      observer.observe(element);
+    });
+  } else {
+    animatedElements.forEach((element) => {
+      element.classList.add('is-visible');
+    });
+  }
 
   const dismissToast = (toast) => {
     if (!toast || toast.classList.contains('is-dismissed')) return;


### PR DESCRIPTION
## Summary
- keep admin sections visible by default so that browsers without JavaScript still show the dashboard
- enable animation styles only after the client script runs and announces support

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ec7b1b7c3083238c77afb2a5bf7edb