### PR TITLE
Fix undefined social metadata variables in head partial

### DIFF
--- a/views/partials/head.ejs
+++ b/views/partials/head.ejs
@@ -20,7 +20,7 @@
   <% if (canonicalLink) { %>
     <link rel="canonical" href="<%= canonicalLink %>" />
   <% } %>
-  <% const ogMeta = openGraph || {}; %>
+  <% const ogMeta = typeof openGraph !== 'undefined' && openGraph ? openGraph : {}; %>
   <meta property="og:title" content="<%= ogMeta.title || (pageTitle ? pageTitle + ' | ' + hotelName : hotelName) %>" />
   <meta property="og:description" content="<%= ogMeta.description || metaDescriptionValue %>" />
   <meta property="og:type" content="<%= ogMeta.type || 'website' %>" />
@@ -33,7 +33,7 @@
   <% if (ogMeta.imageAlt) { %>
     <meta property="og:image:alt" content="<%= ogMeta.imageAlt %>" />
   <% } %>
-  <% const twitterMeta = twitter || {}; %>
+  <% const twitterMeta = typeof twitter !== 'undefined' && twitter ? twitter : {}; %>
   <% if (twitterMeta.card || ogMeta.image) { %>
     <meta name="twitter:card" content="<%= twitterMeta.card || 'summary_large_image' %>" />
   <% } %>


### PR DESCRIPTION
## Summary
- guard the optional Open Graph and Twitter metadata objects in the head partial to avoid ReferenceErrors when templates do not provide them

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ec8144c0788323ad31e969cd9412f9