### PR TITLE
Fix dining server wildcard OPTIONS route for Express 5

### DIFF
--- a/src/dining/server.ts
+++ b/src/dining/server.ts
@@ -89,7 +89,7 @@ const corsOptions: CorsOptions = {
 };
 
 app.use(cors(corsOptions));
-app.options('*', cors(corsOptions));
+app.options(/.*/, cors(corsOptions));
 
 app.set('trust proxy', true);
 app.disable('x-powered-by');


### PR DESCRIPTION
## Summary
- replace the deprecated '*' OPTIONS route with a regular expression handler that Express 5 accepts
- keep CORS preflight support working with the updated routing behaviour

## Testing
- npm run dining:start

------
https://chatgpt.com/codex/tasks/task_e_68ed4ccfd67c8323a49c9f829d3fb24f