### PR TITLE
Relax HSTS and secure cookie handling for local dining

### DIFF
--- a/src/dining/server.ts
+++ b/src/dining/server.ts
@@ -137,7 +137,39 @@ app.use(
   }),
 );
 
-app.use(helmet.hsts({ maxAge: 31536000, includeSubDomains: true }));
+function isLocalHost(hostname: string | undefined | null): boolean {
+  if (!hostname) {
+    return false;
+  }
+  const normalized = hostname.split(':')[0];
+  return normalized === 'localhost' || normalized === '127.0.0.1' || normalized === '::1';
+}
+
+const shouldEnforceHsts = (() => {
+  if (process.env.ENABLE_HSTS === 'true') {
+    return true;
+  }
+  if (process.env.NODE_ENV === 'production') {
+    return true;
+  }
+  const publicBaseUrl = process.env.PUBLIC_BASE_URL;
+  if (typeof publicBaseUrl === 'string' && publicBaseUrl.startsWith('https://')) {
+    return true;
+  }
+  return false;
+})();
+
+if (shouldEnforceHsts) {
+  const hsts = helmet.hsts({ maxAge: 31536000, includeSubDomains: true });
+  app.use((req, res, next) => {
+    const hostHeader = req.get('host');
+    if (hostHeader && isLocalHost(hostHeader)) {
+      next();
+      return;
+    }
+    hsts(req, res, next);
+  });
+}
 app.use(helmet.noSniff());
 app.use((req, res, next) => {
   res.setHeader('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');

--- a/src/middleware/session.js
+++ b/src/middleware/session.js
@@ -10,12 +10,15 @@ const sessionStore = new SQLiteStore({
 
 const sessionCookieName = process.env.SESSION_COOKIE_NAME || 'skyhaven_session';
 const sessionCookieDomain = process.env.SESSION_COOKIE_DOMAIN || undefined;
-const sessionCookieSecure =
-  process.env.SESSION_COOKIE_SECURE === 'true'
-    ? true
-    : process.env.SESSION_COOKIE_SECURE === 'false'
-      ? false
-      : process.env.NODE_ENV === 'production';
+const sessionCookieSecure = (() => {
+  if (process.env.SESSION_COOKIE_SECURE === 'true') {
+    return true;
+  }
+  if (process.env.SESSION_COOKIE_SECURE === 'false') {
+    return false;
+  }
+  return 'auto';
+})();
 
 const sessionMiddleware = session({
   secret: process.env.SESSION_SECRET || 'aurora-nexus-skyhaven-secret',


### PR DESCRIPTION
## Summary
- skip HSTS headers for localhost traffic so browsers do not force HTTPS during development
- let secure session cookies auto-toggle based on request protocol unless explicitly configured

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ed565985088323bd5176d8eeab89c0