### PR TITLE
Fix dining server CORS preflight route pattern

### DIFF
--- a/src/dining/server.ts
+++ b/src/dining/server.ts
@@ -90,7 +90,7 @@ const corsOptions: CorsOptions = {
 };
 
 app.use(cors(corsOptions));
-app.options('(.*)', cors(corsOptions));
+app.options(/.*/, cors(corsOptions));
 
 app.set('trust proxy', true);
 app.disable('x-powered-by');


### PR DESCRIPTION
## Summary
- replace deprecated path-to-regexp wildcard pattern with a regular expression for the OPTIONS CORS route

## Testing
- npm run dining:start

------
https://chatgpt.com/codex/tasks/task_e_68ed7afa285483239be291936c8e2bd0