### PR TITLE
Fix admin page animation visibility

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1,4 +1,11 @@
 (() => {
+  const adminSection = document.querySelector('.admin[data-animate]');
+  if (adminSection && !adminSection.classList.contains('is-visible')) {
+    requestAnimationFrame(() => {
+      adminSection.classList.add('is-visible');
+    });
+  }
+
   const inquiryList = document.querySelector('[data-inquiry-list]');
   if (!inquiryList || typeof window.io !== 'function') {
     return;


### PR DESCRIPTION
## Summary
- ensure the admin overview section is forced visible after load so that it animates in instead of remaining hidden
- keep existing admin inquiry socket handling intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68edb6408a10832386e9c259da5da8d2