### PR TITLE
Prevent rate limiter redirect loops

### DIFF
--- a/views/429.ejs
+++ b/views/429.ejs
@@ -1,0 +1,10 @@
+<%- include('partials/head', { pageTitle, hotelName, csrfToken, darkMode }) %>
+<%- include('partials/nav') %>
+<%- include('partials/alerts') %>
+<section class="error-page" data-animate="fade-up">
+  <h1>Transmission Overload</h1>
+  <p><%= friendlyMessage %> Please pause for <strong><%= retryAfter %> seconds</strong> before trying again.</p>
+  <p>If you believe this relay activated by mistake, wait a moment and refresh the page to continue your journey.</p>
+  <a class="cta-button primary" href="/">Return Home</a>
+</section>
+<%- include('partials/footer') %>


### PR DESCRIPTION
## Summary
- stop rate limiter from redirecting back to the same page and render a dedicated 429 view instead
- add a fallback proxy middleware stub for test environments where http-proxy-middleware is unavailable

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68edb89cf41483239a406bb74993b7f2