### PR TITLE
Enhance dining experiences and admin controls

### DIFF
--- a/public/css/dining.css
+++ b/public/css/dining.css
@@ -129,6 +129,248 @@
   border: 1px solid rgba(207, 168, 88, 0.25);
 }
 
+.dining-team {
+  margin-top: 4.5rem;
+  display: grid;
+  gap: 2rem;
+  background: linear-gradient(160deg, rgba(10, 14, 28, 0.92), rgba(7, 10, 20, 0.88));
+  border: 1px solid rgba(207, 168, 88, 0.2);
+  border-radius: 24px;
+  padding: 2.5rem;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+}
+
+.dining-team header {
+  display: grid;
+  gap: 0.75rem;
+  max-width: 640px;
+}
+
+.dining-team__controls {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  align-items: start;
+}
+
+.dining-team__search input {
+  width: 100%;
+  background: rgba(7, 9, 20, 0.85);
+  border: 1px solid rgba(207, 168, 88, 0.35);
+  border-radius: 999px;
+  padding: 0.85rem 1.2rem;
+  color: var(--dining-text);
+  font-size: 1rem;
+  transition: border-color var(--transition-snappy), box-shadow var(--transition-snappy);
+}
+
+.dining-team__search input:focus-visible {
+  outline: none;
+  border-color: var(--dining-accent);
+  box-shadow: 0 0 0 3px rgba(207, 168, 88, 0.2);
+}
+
+.dining-team__roles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.role-chip {
+  border: 1px solid rgba(207, 168, 88, 0.35);
+  background: rgba(5, 7, 15, 0.6);
+  color: var(--dining-text);
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background var(--transition-snappy), transform var(--transition-snappy), border-color var(--transition-snappy);
+}
+
+.role-chip:hover,
+.role-chip:focus-visible {
+  background: rgba(207, 168, 88, 0.15);
+  border-color: rgba(207, 168, 88, 0.65);
+  outline: none;
+}
+
+.role-chip.is-active {
+  background: rgba(207, 168, 88, 0.25);
+  color: #0b1021;
+  border-color: rgba(207, 168, 88, 0.85);
+  box-shadow: 0 10px 28px rgba(207, 168, 88, 0.25);
+}
+
+.dining-team__toggles {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(207, 168, 88, 0.35);
+  background: rgba(5, 7, 15, 0.6);
+  color: var(--dining-text);
+  cursor: pointer;
+}
+
+.toggle input {
+  accent-color: var(--dining-accent);
+  transform: scale(1.1);
+}
+
+.toggle span {
+  display: grid;
+  gap: 0.1rem;
+}
+
+.toggle span strong {
+  font-size: 0.95rem;
+}
+
+.toggle span small {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--dining-muted);
+}
+
+.btn-compact {
+  padding: 0.6rem 1.1rem;
+  font-size: 0.85rem;
+}
+
+.dining-team__count {
+  font-size: 0.9rem;
+  color: rgba(226, 230, 248, 0.75);
+}
+
+.dining-team__grid {
+  display: grid;
+  gap: 1.6rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.dining-team__card {
+  position: relative;
+  display: grid;
+  gap: 1rem;
+  padding: 1.6rem;
+  border-radius: 20px;
+  background: rgba(10, 14, 28, 0.92);
+  border: 1px solid rgba(207, 168, 88, 0.18);
+  transition: transform var(--transition-snappy), border-color var(--transition-snappy), box-shadow var(--transition-snappy);
+}
+
+.dining-team__card:hover {
+  transform: translateY(-6px);
+  border-color: rgba(207, 168, 88, 0.45);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+}
+
+.dining-team__card.is-hidden {
+  display: none;
+}
+
+.dining-team__card header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.dining-team__role {
+  font-size: 0.95rem;
+  color: rgba(226, 230, 248, 0.7);
+}
+
+.pin-toggle {
+  border: 1px solid rgba(207, 168, 88, 0.4);
+  background: rgba(5, 7, 15, 0.75);
+  color: var(--dining-accent);
+  border-radius: 50%;
+  width: 2.3rem;
+  height: 2.3rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform var(--transition-snappy), background var(--transition-snappy);
+}
+
+.pin-toggle:hover,
+.pin-toggle:focus-visible {
+  transform: scale(1.08);
+  background: rgba(207, 168, 88, 0.15);
+  outline: none;
+}
+
+.pin-toggle[aria-pressed='true'] {
+  background: rgba(207, 168, 88, 0.3);
+  color: #0b1021;
+  border-color: rgba(207, 168, 88, 0.8);
+}
+
+.dining-team__card.is-pinned {
+  border-color: rgba(207, 168, 88, 0.8);
+  box-shadow: 0 0 0 2px rgba(207, 168, 88, 0.35), 0 16px 36px rgba(207, 168, 88, 0.2);
+}
+
+.dining-team__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.dining-team__badges li {
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  background: rgba(80, 130, 255, 0.18);
+  color: rgba(198, 211, 255, 0.9);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.dining-team__meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  font-size: 0.85rem;
+  color: rgba(226, 230, 248, 0.75);
+}
+
+.dining-team__meta time {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: rgba(207, 168, 88, 0.85);
+}
+
+.countdown {
+  font-weight: 600;
+  letter-spacing: 0.05em;
+}
+
+@media (max-width: 720px) {
+  .dining-team {
+    padding: 2rem;
+  }
+
+  .dining-team__controls {
+    grid-template-columns: 1fr;
+  }
+}
+
 .eyebrow {
   text-transform: uppercase;
   letter-spacing: 0.25em;

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1166,6 +1166,356 @@ textarea:focus {
   animation: admin-panel-in 0.6s ease forwards;
 }
 
+.admin-panel--dining {
+  gap: 1.6rem;
+}
+
+.dining-console__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.dining-console__header h2 {
+  margin-bottom: 0.35rem;
+}
+
+.dining-console__metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: stretch;
+}
+
+.console-metric {
+  background: rgba(94, 252, 255, 0.08);
+  border: 1px solid rgba(94, 252, 255, 0.2);
+  border-radius: 16px;
+  padding: 1rem 1.35rem;
+  display: grid;
+  gap: 0.35rem;
+  min-width: 160px;
+}
+
+.console-label {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.7rem;
+  color: var(--color-muted);
+}
+
+.console-status {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.console-status .status-chip {
+  background: rgba(12, 24, 40, 0.75);
+  border: 1px solid rgba(94, 252, 255, 0.25);
+  border-radius: 14px;
+  padding: 0.65rem 0.85rem;
+  display: grid;
+  gap: 0.3rem;
+  min-width: 120px;
+}
+
+.console-status .status-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-muted);
+}
+
+.console-status strong {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: rgba(226, 234, 255, 0.85);
+}
+
+.switch input {
+  transform: scale(1.05);
+  accent-color: var(--color-primary);
+}
+
+.switch span {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-muted);
+}
+
+.dining-console__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(10, 16, 28, 0.7);
+  border: 1px solid rgba(94, 252, 255, 0.18);
+  border-radius: 18px;
+  padding: 1.1rem 1.4rem;
+}
+
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.control-group--actions {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.control-label {
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.68rem;
+  color: var(--color-muted);
+}
+
+.control-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.dining-console__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+}
+
+.seat-board {
+  display: grid;
+  gap: 0.9rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.seat-chip {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.95rem 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(94, 252, 255, 0.25);
+  background: rgba(10, 16, 28, 0.85);
+  color: #f5fbff;
+  text-align: left;
+  cursor: pointer;
+  transition: transform var(--transition-snappy), border-color var(--transition-snappy), box-shadow var(--transition-snappy);
+}
+
+.seat-chip:hover,
+.seat-chip:focus-visible {
+  transform: translateY(-3px);
+  border-color: rgba(94, 252, 255, 0.5);
+  box-shadow: 0 12px 30px rgba(7, 20, 32, 0.5);
+  outline: none;
+}
+
+.seat-chip__label {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.seat-chip__meta {
+  font-size: 0.8rem;
+  color: var(--color-muted);
+}
+
+.seat-chip.status-available {
+  border-color: rgba(94, 252, 255, 0.45);
+}
+
+.seat-chip.status-held {
+  border-color: rgba(255, 205, 112, 0.55);
+  background: rgba(38, 28, 12, 0.75);
+}
+
+.seat-chip.status-reserved {
+  border-color: rgba(255, 107, 154, 0.6);
+  background: rgba(40, 14, 24, 0.75);
+}
+
+.seat-chip.is-hidden {
+  display: none;
+}
+
+.seat-chip.is-updated {
+  animation: seat-chip-pulse 0.75s ease;
+}
+
+@keyframes seat-chip-pulse {
+  from {
+    box-shadow: 0 0 0 0 rgba(94, 252, 255, 0.35);
+  }
+  to {
+    box-shadow: 0 0 0 16px transparent;
+  }
+}
+
+.coverage-panel {
+  display: grid;
+  gap: 1rem;
+  background: rgba(8, 14, 26, 0.85);
+  border: 1px solid rgba(94, 252, 255, 0.18);
+  border-radius: 20px;
+  padding: 1.2rem 1.4rem;
+}
+
+.coverage-panel > header {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.coverage-summary {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.coverage-summary li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  background: rgba(10, 16, 28, 0.75);
+  border: 1px solid rgba(94, 252, 255, 0.18);
+  border-radius: 12px;
+  padding: 0.6rem 0.75rem;
+}
+
+.coverage-summary .count {
+  font-weight: 600;
+}
+
+.coverage-roster {
+  display: grid;
+  gap: 0.9rem;
+  max-height: 340px;
+  overflow: auto;
+  padding-right: 0.4rem;
+}
+
+.coverage-card {
+  position: relative;
+  display: grid;
+  gap: 0.6rem;
+  background: rgba(6, 12, 24, 0.88);
+  border: 1px solid rgba(94, 252, 255, 0.18);
+  border-radius: 16px;
+  padding: 1rem 1.2rem;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.coverage-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.coverage-card .role {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.coverage-card .badge-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.coverage-card .badge-list li {
+  background: rgba(94, 252, 255, 0.15);
+  border-radius: 999px;
+  padding: 0.3rem 0.65rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.coverage-card__meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.78rem;
+  color: var(--color-muted);
+}
+
+.coverage-card__meta time {
+  font-family: var(--font-mono);
+  color: rgba(94, 252, 255, 0.8);
+  font-size: 0.75rem;
+}
+
+.coverage-card.is-muted {
+  opacity: 0.35;
+  filter: saturate(0.45);
+}
+
+.coverage-card.is-pulsing {
+  border-color: rgba(94, 252, 255, 0.6);
+  box-shadow: 0 0 25px rgba(94, 252, 255, 0.25);
+  animation: coverage-pulse 1.4s ease-in-out infinite alternate;
+}
+
+@keyframes coverage-pulse {
+  from {
+    box-shadow: 0 0 20px rgba(94, 252, 255, 0.2);
+  }
+  to {
+    box-shadow: 0 0 45px rgba(94, 252, 255, 0.35);
+  }
+}
+
+@media (max-width: 1024px) {
+  .dining-console__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .dining-console__metrics {
+    width: 100%;
+  }
+}
+
+@media (max-width: 720px) {
+  .dining-console__controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .control-group--actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .console-status {
+    width: 100%;
+  }
+}
+
 .admin-grid > .admin-panel:nth-of-type(1) {
   animation-delay: 0.05s;
 }

--- a/public/js/admin-dining-console.js
+++ b/public/js/admin-dining-console.js
@@ -1,0 +1,219 @@
+(function () {
+  const root = document.querySelector('[data-dining-console]');
+  if (!root) return;
+
+  const seatBoard = root.querySelector('[data-seat-board]');
+  const seatButtons = Array.from(root.querySelectorAll('[data-seat-id]'));
+  const filterButtons = Array.from(root.querySelectorAll('[data-seat-filter]'));
+  const clusterToggle = root.querySelector('[data-seat-cluster]');
+  const refreshButton = root.querySelector('[data-seat-refresh]');
+  const simulateButton = root.querySelector('[data-seat-randomize]');
+  const seatCountEl = root.querySelector('[data-seat-count]');
+  const summaryItems = Array.from(root.querySelectorAll('[data-status-count]'));
+  const roleToggles = Array.from(root.querySelectorAll('[data-role-toggle]'));
+  const coverageCards = Array.from(root.querySelectorAll('[data-coverage-card]'));
+  const shiftButtons = Array.from(root.querySelectorAll('[data-toggle-shift]'));
+
+  if (!seatBoard || !seatButtons.length) return;
+
+  const defaultOrder = seatButtons.slice();
+  const initialStatuses = new Map();
+  seatButtons.forEach((button) => {
+    initialStatuses.set(button.dataset.seatId, button.dataset.seatStatus || 'available');
+  });
+
+  let activeFilter = 'all';
+
+  function updateSeatCount() {
+    if (!seatCountEl) return;
+    const visible = seatButtons.filter((btn) => !btn.classList.contains('is-hidden')).length;
+    seatCountEl.textContent = `${visible} / ${seatButtons.length}`;
+  }
+
+  function updateSeatSummary() {
+    const counts = seatButtons.reduce((acc, button) => {
+      if (button.classList.contains('is-hidden')) {
+        return acc;
+      }
+      const status = button.dataset.seatStatus || 'available';
+      acc[status] = (acc[status] || 0) + 1;
+      return acc;
+    }, {});
+
+    summaryItems.forEach((item) => {
+      const status = item.dataset.statusCount;
+      if (!status) return;
+      item.textContent = counts[status] || 0;
+    });
+  }
+
+  function setSeatStatus(button, status) {
+    const previous = button.dataset.seatStatus;
+    button.classList.remove(`status-${previous}`);
+    button.dataset.seatStatus = status;
+    button.classList.add(`status-${status}`);
+  }
+
+  function flash(button) {
+    button.classList.remove('is-updated');
+    // trigger reflow for restart animation
+    void button.offsetWidth;
+    button.classList.add('is-updated');
+  }
+
+  function cycleSeat(button) {
+    const statuses = ['available', 'held', 'reserved'];
+    const current = button.dataset.seatStatus || 'available';
+    const next = statuses[(statuses.indexOf(current) + 1) % statuses.length];
+    setSeatStatus(button, next);
+    flash(button);
+    applyFilter(activeFilter);
+  }
+
+  function applyFilter(filter) {
+    activeFilter = filter;
+    seatButtons.forEach((button) => {
+      const matches = filter === 'all' || button.dataset.seatStatus === filter;
+      button.classList.toggle('is-hidden', !matches);
+    });
+    updateSeatCount();
+    updateSeatSummary();
+  }
+
+  function sortSeats(comparator) {
+    const sorted = seatButtons.slice().sort(comparator);
+    sorted.forEach((button) => seatBoard.appendChild(button));
+  }
+
+  function alphabetComparator(a, b) {
+    const aLabel = a.dataset.seatLabel || '';
+    const bLabel = b.dataset.seatLabel || '';
+    return aLabel.localeCompare(bLabel);
+  }
+
+  function zoneComparator(a, b) {
+    const aZone = (a.dataset.seatZone || '').toLowerCase();
+    const bZone = (b.dataset.seatZone || '').toLowerCase();
+    if (aZone !== bZone) {
+      return aZone.localeCompare(bZone);
+    }
+    return alphabetComparator(a, b);
+  }
+
+  function resetSnapshot() {
+    defaultOrder.forEach((button) => {
+      const status = initialStatuses.get(button.dataset.seatId) || 'available';
+      setSeatStatus(button, status);
+      button.classList.remove('is-hidden', 'is-updated');
+      seatBoard.appendChild(button);
+    });
+
+    filterButtons.forEach((btn) => {
+      const isActive = btn.dataset.seatFilter === 'all';
+      btn.classList.toggle('is-active', isActive);
+      btn.setAttribute('aria-pressed', String(isActive));
+    });
+    activeFilter = 'all';
+
+    if (clusterToggle) {
+      clusterToggle.checked = false;
+    }
+
+    updateSeatCount();
+    updateSeatSummary();
+  }
+
+  function simulateRush() {
+    const statuses = ['available', 'held', 'reserved'];
+    seatButtons.forEach((button) => {
+      const randomStatus = statuses[Math.floor(Math.random() * statuses.length)];
+      setSeatStatus(button, randomStatus);
+      flash(button);
+    });
+    applyFilter(activeFilter);
+  }
+
+  function updateCoverageCountdown() {
+    const now = Date.now();
+    coverageCards.forEach((card) => {
+      const countdown = card.querySelector('[data-coverage-countdown]');
+      if (!countdown) return;
+      const shift = Date.parse(card.dataset.shift || '');
+      if (Number.isNaN(shift)) {
+        countdown.textContent = 'Shift timing pending';
+        return;
+      }
+      const diff = shift - now;
+      if (Math.abs(diff) < 60000) {
+        countdown.textContent = 'On deck';
+        return;
+      }
+      const minutes = Math.round(Math.abs(diff) / 60000);
+      if (minutes >= 60) {
+        const hours = Math.round(minutes / 60);
+        countdown.textContent = diff > 0 ? `in ${hours}h` : `${hours}h ago`;
+      } else {
+        countdown.textContent = diff > 0 ? `in ${minutes}m` : `${minutes}m ago`;
+      }
+    });
+  }
+
+  seatButtons.forEach((button) => {
+    button.addEventListener('click', () => cycleSeat(button));
+  });
+
+  filterButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const filter = button.dataset.seatFilter || 'all';
+      filterButtons.forEach((btn) => {
+        const isActive = btn === button;
+        btn.classList.toggle('is-active', isActive);
+        btn.setAttribute('aria-pressed', String(isActive));
+      });
+      applyFilter(filter);
+    });
+  });
+
+  if (clusterToggle) {
+    clusterToggle.addEventListener('change', () => {
+      sortSeats(clusterToggle.checked ? zoneComparator : alphabetComparator);
+    });
+  }
+
+  if (refreshButton) {
+    refreshButton.addEventListener('click', () => {
+      resetSnapshot();
+      sortSeats(alphabetComparator);
+    });
+  }
+
+  if (simulateButton) {
+    simulateButton.addEventListener('click', () => {
+      simulateRush();
+    });
+  }
+
+  roleToggles.forEach((toggle) => {
+    toggle.addEventListener('change', () => {
+      const role = (toggle.value || '').toLowerCase();
+      coverageCards.forEach((card) => {
+        if (card.dataset.role === role) {
+          card.classList.toggle('is-muted', !toggle.checked);
+        }
+      });
+    });
+  });
+
+  shiftButtons.forEach((button) => {
+    button.addEventListener('click', (event) => {
+      const card = event.currentTarget.closest('[data-coverage-card]');
+      if (!card) return;
+      card.classList.toggle('is-pulsing');
+    });
+  });
+
+  applyFilter('all');
+  sortSeats(alphabetComparator);
+  updateCoverageCountdown();
+  window.setInterval(updateCoverageCountdown, 60000);
+})();

--- a/public/js/dining-roster.js
+++ b/public/js/dining-roster.js
@@ -1,0 +1,228 @@
+(function () {
+  const root = document.querySelector('[data-dining-roster]');
+  if (!root) return;
+
+  const searchInput = root.querySelector('[data-roster-search]');
+  const roleButtons = Array.from(root.querySelectorAll('[data-role-filter]'));
+  const sortToggle = root.querySelector('[data-roster-sort]');
+  const sortLabel = root.querySelector('[data-sort-label]');
+  const clearPinsButton = root.querySelector('[data-clear-pins]');
+  const countEl = root.querySelector('[data-roster-count]');
+  const list = root.querySelector('[data-roster-list]');
+  if (!list) return;
+
+  const cards = Array.from(list.querySelectorAll('[data-roster-card]'));
+  const storageKey = 'dining-roster:pins';
+  let pinnedSet = new Set();
+
+  try {
+    const stored = JSON.parse(window.localStorage.getItem(storageKey));
+    if (Array.isArray(stored)) {
+      pinnedSet = new Set(stored);
+    }
+  } catch (error) {
+    pinnedSet = new Set();
+  }
+
+  const state = {
+    role: 'all',
+    query: '',
+    sort: 'alpha'
+  };
+
+  const relativeFormatter =
+    typeof Intl !== 'undefined' && typeof Intl.RelativeTimeFormat !== 'undefined'
+      ? new Intl.RelativeTimeFormat('en', { numeric: 'auto' })
+      : null;
+
+  function savePins() {
+    try {
+      window.localStorage.setItem(storageKey, JSON.stringify(Array.from(pinnedSet)));
+    } catch (error) {
+      // Ignore storage issues (private mode, quota, etc.).
+    }
+  }
+
+  function updateCount(visible) {
+    if (!countEl) return;
+    const total = cards.length;
+    const descriptor = total === 1 ? 'culinary artist' : 'culinary artists';
+    countEl.textContent = `${visible} of ${total} ${descriptor} visible`;
+  }
+
+  function applyFilters() {
+    const query = state.query.trim();
+    let visible = 0;
+
+    cards.forEach((card) => {
+      const role = card.dataset.role || '';
+      const haystack = `${card.dataset.name || ''} ${role} ${card.dataset.badges || ''}`;
+      const matchesRole = state.role === 'all' || role === state.role;
+      const matchesQuery = !query || haystack.includes(query);
+      const shouldShow = matchesRole && matchesQuery;
+
+      card.classList.toggle('is-hidden', !shouldShow);
+      card.setAttribute('aria-hidden', String(!shouldShow));
+      if (shouldShow) {
+        visible += 1;
+      }
+    });
+
+    updateCount(visible);
+  }
+
+  function sortCards() {
+    const sorted = cards.slice().sort((a, b) => {
+      const aPinned = pinnedSet.has(a.dataset.id);
+      const bPinned = pinnedSet.has(b.dataset.id);
+      if (aPinned !== bPinned) {
+        return aPinned ? -1 : 1;
+      }
+
+      if (state.sort === 'shift') {
+        const aShift = Date.parse(a.dataset.shift || '');
+        const bShift = Date.parse(b.dataset.shift || '');
+        if (!Number.isNaN(aShift) && !Number.isNaN(bShift) && aShift !== bShift) {
+          return aShift - bShift;
+        }
+      }
+
+      const aName = a.dataset.name || '';
+      const bName = b.dataset.name || '';
+      return aName.localeCompare(bName);
+    });
+
+    sorted.forEach((card) => {
+      list.appendChild(card);
+    });
+  }
+
+  function updateCountdown() {
+    const now = Date.now();
+
+    cards.forEach((card) => {
+      const countdownEl = card.querySelector('[data-countdown]');
+      if (!countdownEl) return;
+
+      const shift = Date.parse(card.dataset.shift || '');
+      if (Number.isNaN(shift)) {
+        countdownEl.textContent = 'Shift timing pending';
+        return;
+      }
+
+      const diff = shift - now;
+      if (Math.abs(diff) < 60000) {
+        countdownEl.textContent = 'In service now';
+        return;
+      }
+
+      if (relativeFormatter) {
+        const thresholds = [
+          { unit: 'day', value: 86400000 },
+          { unit: 'hour', value: 3600000 },
+          { unit: 'minute', value: 60000 }
+        ];
+        for (const threshold of thresholds) {
+          if (Math.abs(diff) >= threshold.value || threshold.unit === 'minute') {
+            const value = Math.round(diff / threshold.value);
+            countdownEl.textContent = relativeFormatter.format(value, threshold.unit);
+            return;
+          }
+        }
+      }
+
+      const minutes = Math.round(Math.abs(diff) / 60000);
+      if (minutes >= 60) {
+        const hours = Math.round(minutes / 60);
+        countdownEl.textContent = diff > 0 ? `in ${hours}h` : `${hours}h ago`;
+      } else {
+        countdownEl.textContent = diff > 0 ? `in ${minutes}m` : `${minutes}m ago`;
+      }
+    });
+  }
+
+  function togglePin(card, button) {
+    const id = card.dataset.id;
+    if (!id) return;
+
+    const wasPinned = pinnedSet.has(id);
+    if (wasPinned) {
+      pinnedSet.delete(id);
+    } else {
+      pinnedSet.add(id);
+    }
+
+    card.classList.toggle('is-pinned', !wasPinned);
+    if (button) {
+      button.setAttribute('aria-pressed', String(!wasPinned));
+      button.textContent = !wasPinned ? '★' : '☆';
+    }
+
+    savePins();
+    sortCards();
+  }
+
+  cards.forEach((card) => {
+    const pinButton = card.querySelector('[data-pin]');
+    const id = card.dataset.id;
+    if (pinButton) {
+      const isPinned = pinnedSet.has(id);
+      card.classList.toggle('is-pinned', isPinned);
+      pinButton.setAttribute('aria-pressed', String(isPinned));
+      pinButton.textContent = isPinned ? '★' : '☆';
+      pinButton.addEventListener('click', () => togglePin(card, pinButton));
+    }
+  });
+
+  if (searchInput) {
+    searchInput.addEventListener('input', (event) => {
+      state.query = event.target.value.toLowerCase();
+      applyFilters();
+    });
+  }
+
+  roleButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const value = button.dataset.roleFilter || 'all';
+      state.role = value;
+      roleButtons.forEach((btn) => {
+        const isActive = btn === button;
+        btn.classList.toggle('is-active', isActive);
+        btn.setAttribute('aria-pressed', String(isActive));
+      });
+      applyFilters();
+      sortCards();
+    });
+  });
+
+  if (sortToggle) {
+    sortToggle.addEventListener('change', () => {
+      state.sort = sortToggle.checked ? 'shift' : 'alpha';
+      if (sortLabel) {
+        sortLabel.textContent = sortToggle.checked ? 'Upcoming shifts' : 'Alphabetical order';
+      }
+      sortCards();
+    });
+  }
+
+  if (clearPinsButton) {
+    clearPinsButton.addEventListener('click', () => {
+      pinnedSet.clear();
+      cards.forEach((card) => {
+        card.classList.remove('is-pinned');
+        const button = card.querySelector('[data-pin]');
+        if (button) {
+          button.setAttribute('aria-pressed', 'false');
+          button.textContent = '☆';
+        }
+      });
+      savePins();
+      sortCards();
+    });
+  }
+
+  applyFilters();
+  sortCards();
+  updateCountdown();
+  window.setInterval(updateCountdown, 60000);
+})();

--- a/src/routes/dining.js
+++ b/src/routes/dining.js
@@ -76,6 +76,15 @@ router.use(async (req, res, next) => {
 router.get('/dining', (req, res) => {
   const canonicalUrl = buildAbsoluteUrl(req, '/dining');
   const ogImage = buildAbsoluteUrl(req, '/images/nebula.svg');
+  const staff = listStaff();
+  const staffRoles = Array.from(
+    new Set(
+      staff
+        .map((member) => member.role)
+        .filter((role) => typeof role === 'string' && role.trim().length > 0)
+        .map((role) => role.trim())
+    )
+  ).sort((a, b) => a.localeCompare(b));
   const restaurantJsonLd = {
     '@context': 'https://schema.org',
     '@type': 'Restaurant',
@@ -131,6 +140,8 @@ router.get('/dining', (req, res) => {
         background: 'linear-gradient(135deg, rgba(212,36,78,0.4), rgba(12,20,40,0.95))',
       },
     ],
+    staff,
+    staffRoles,
   });
 });
 

--- a/views/admin/index.ejs
+++ b/views/admin/index.ejs
@@ -1,4 +1,5 @@
 <%- include('../partials/head', { pageTitle, hotelName, csrfToken, darkMode }) %>
+<script defer src="/js/admin-dining-console.js"></script>
 <%- include('../partials/nav') %>
 <%- include('../partials/alerts') %>
 
@@ -284,6 +285,116 @@
           </li>
         <% }) %>
       </ul>
+    </section>
+
+    <section class="admin-panel admin-panel--dining" data-dining-console>
+      <div class="dining-console__header">
+        <div>
+          <h2>Dining command console</h2>
+          <p>Balance Supper Club seats, orchestrate coverage, and simulate rush moments in one control surface.</p>
+        </div>
+        <div class="dining-console__metrics">
+          <div class="console-metric">
+            <span class="console-label">Tables visible</span>
+            <strong data-seat-count><%= diningSeats.length %> / <%= diningSeats.length %></strong>
+          </div>
+          <ul class="console-status" data-seat-summary>
+            <% diningSeatSummary.forEach(function(item) { %>
+              <% const statusLabel = item.status.charAt(0).toUpperCase() + item.status.slice(1); %>
+              <li class="status-chip status-<%= item.status %>">
+                <span class="status-label"><%= statusLabel %></span>
+                <strong data-status-count="<%= item.status %>"><%= item.count %></strong>
+              </li>
+            <% }) %>
+          </ul>
+        </div>
+      </div>
+      <div class="dining-console__controls">
+        <div class="control-group">
+          <span class="control-label">Seat status</span>
+          <div class="control-actions">
+            <button type="button" class="pill-link secondary is-active" data-seat-filter="all" aria-pressed="true">All</button>
+            <button type="button" class="pill-link secondary" data-seat-filter="available" aria-pressed="false">Available</button>
+            <button type="button" class="pill-link secondary" data-seat-filter="held" aria-pressed="false">Held</button>
+            <button type="button" class="pill-link secondary" data-seat-filter="reserved" aria-pressed="false">Reserved</button>
+          </div>
+        </div>
+        <div class="control-group">
+          <label class="switch">
+            <input type="checkbox" data-seat-cluster>
+            <span>Cluster seats by zone</span>
+          </label>
+        </div>
+        <div class="control-group control-group--actions">
+          <button type="button" class="btn btn-outline" data-seat-refresh>Reset snapshot</button>
+          <button type="button" class="btn btn-outline" data-seat-randomize>Simulate rush</button>
+        </div>
+      </div>
+      <div class="dining-console__grid">
+        <div class="seat-board" data-seat-board>
+          <% diningSeats.forEach(function(seat) { %>
+            <% const seatStatus = (seat.status || 'available').toLowerCase(); %>
+            <button
+              type="button"
+              class="seat-chip status-<%= seatStatus %>"
+              data-seat-id="<%= seat.id %>"
+              data-seat-label="<%= seat.label %>"
+              data-seat-status="<%= seatStatus %>"
+              data-seat-zone="<%= seat.zone %>"
+              data-seat-capacity="<%= seat.capacity %>"
+            >
+              <span class="seat-chip__label"><%= seat.label %></span>
+              <span class="seat-chip__meta"><%= seat.capacity %> guests • <%= seat.zone %></span>
+            </button>
+          <% }) %>
+        </div>
+        <div class="coverage-panel">
+          <header>
+            <h3>Shift coverage</h3>
+            <p>Toggle visibility by role and pulse key hosts before the next seating.</p>
+          </header>
+          <ul class="coverage-summary">
+            <% diningCoverage.forEach(function(item) { %>
+              <li>
+                <span><%= item.role %></span>
+                <span class="count"><%= item.count %></span>
+                <label class="switch">
+                  <input type="checkbox" data-role-toggle value="<%= item.role %>" checked>
+                  <span>Display</span>
+                </label>
+              </li>
+            <% }) %>
+          </ul>
+          <div class="coverage-roster" data-coverage-roster>
+            <% diningStaff.forEach(function(member) { %>
+              <article
+                class="coverage-card"
+                data-coverage-card
+                data-role="<%= (member.role || '').toLowerCase() %>"
+                data-name="<%= (member.name || '').toLowerCase() %>"
+                data-shift="<%= member.nextShift %>"
+              >
+                <header>
+                  <h4><%= member.name %></h4>
+                  <span class="role"><%= member.role %></span>
+                </header>
+                <% if (Array.isArray(member.badges) && member.badges.length) { %>
+                  <ul class="badge-list">
+                    <% member.badges.forEach(function(badge) { %>
+                      <li><%= badge %></li>
+                    <% }) %>
+                  </ul>
+                <% } %>
+                <div class="coverage-card__meta">
+                  <span data-coverage-countdown>Shift syncing…</span>
+                  <time datetime="<%= member.nextShift %>"><%= new Date(member.nextShift).toLocaleString() %></time>
+                </div>
+                <button type="button" class="pill-link" data-toggle-shift>Pulse focus</button>
+              </article>
+            <% }) %>
+          </div>
+        </div>
+      </div>
     </section>
 
     <section class="admin-panel">

--- a/views/dining/landing.ejs
+++ b/views/dining/landing.ejs
@@ -1,5 +1,6 @@
 <%- include('../partials/head', { pageTitle: title, hotelName, csrfToken, darkMode }) %>
 <link rel="stylesheet" href="/css/dining.css">
+<script defer src="/js/dining-roster.js"></script>
 <%- include('../partials/nav') %>
 <%- include('../partials/alerts') %>
 <main class="dining-landing" data-theme="dining">
@@ -53,5 +54,81 @@
       </div>
     </dl>
   </section>
+  <% if (staff && staff.length) { %>
+    <section class="dining-team" data-dining-roster>
+      <header>
+        <h2>Meet the Aurora Brigade</h2>
+        <p>Search the entire dining ensemble, pin your favourite hosts, and choreograph shifts with live cadence tools.</p>
+      </header>
+      <div class="dining-team__controls">
+        <div class="dining-team__search">
+          <label for="dining-roster-search" class="sr-only">Search dining staff</label>
+          <input
+            id="dining-roster-search"
+            type="search"
+            placeholder="Search by name, role, or badge"
+            data-roster-search
+            autocomplete="off"
+          >
+        </div>
+        <div class="dining-team__roles" role="group" aria-label="Filter by role">
+          <button type="button" class="role-chip is-active" data-role-filter="all" aria-pressed="true">All roles</button>
+          <% staffRoles.forEach((role) => { %>
+            <button
+              type="button"
+              class="role-chip"
+              data-role-filter="<%= role.toLowerCase() %>"
+              aria-pressed="false"
+            >
+              <%= role %>
+            </button>
+          <% }) %>
+        </div>
+        <div class="dining-team__toggles">
+          <label class="toggle">
+            <input type="checkbox" data-roster-sort>
+            <span>
+              <strong data-sort-label>Alphabetical order</strong>
+              <small>Toggle for upcoming shift view</small>
+            </span>
+          </label>
+          <button type="button" class="btn btn-outline btn-compact" data-clear-pins>Clear pinned</button>
+        </div>
+      </div>
+      <p class="dining-team__count" data-roster-count><%= staff.length %> culinary artists online</p>
+      <div class="dining-team__grid" data-roster-list>
+        <% staff.forEach((member) => { %>
+          <article
+            class="dining-team__card"
+            data-roster-card
+            data-id="<%= member.id %>"
+            data-name="<%= (member.name || '').toLowerCase() %>"
+            data-role="<%= (member.role || '').toLowerCase() %>"
+            data-badges="<%= Array.isArray(member.badges) ? member.badges.join(' ').toLowerCase() : '' %>"
+            data-shift="<%= member.nextShift %>"
+          >
+            <header>
+              <div>
+                <h3><%= member.name %></h3>
+                <p class="dining-team__role"><%= member.role %></p>
+              </div>
+              <button class="pin-toggle" type="button" data-pin aria-pressed="false" title="Pin <%= member.name %>">☆</button>
+            </header>
+            <% if (Array.isArray(member.badges) && member.badges.length) { %>
+              <ul class="dining-team__badges">
+                <% member.badges.forEach((badge) => { %>
+                  <li><%= badge %></li>
+                <% }) %>
+              </ul>
+            <% } %>
+            <div class="dining-team__meta">
+              <span class="countdown" data-countdown>Shift timing synced</span>
+              <time datetime="<%= member.nextShift %>"><%= new Date(member.nextShift).toLocaleString() %></time>
+            </div>
+          </article>
+        <% }) %>
+      </div>
+    </section>
+  <% } %>
 </main>
 <%- include('../partials/footer') %>


### PR DESCRIPTION
## Summary
- add an interactive dining roster with filtering, pinning, and shift awareness directly to the /dining landing page
- surface dining staff and seat data within the main admin console with new controls for filtering, clustering, and simulating demand
- introduce dedicated scripts and styling for the dining roster and admin command console, including responsive layouts and animations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68edbb910fdc832399f6f878b5560e66