### PR TITLE
Center confirmation CTA in dining confirmation view

### DIFF
--- a/public/css/dining-reserve.css
+++ b/public/css/dining-reserve.css
@@ -340,6 +340,14 @@
   justify-content: flex-end;
 }
 
+.reserve-card--success .reserve-actions {
+  justify-content: center;
+}
+
+.reserve-card--success .reserve-actions .reserve-primary {
+  min-width: 14rem;
+}
+
 .reserve-seatmap-wrapper {
   overflow: hidden;
   border-radius: 0.85rem;
@@ -832,6 +840,15 @@
 @media (max-width: 767px) {
   .reserve-seatmap-wrapper {
     overflow: auto;
+  }
+
+  .reserve-card--success .reserve-actions {
+    width: 100%;
+  }
+
+  .reserve-card--success .reserve-actions .reserve-primary {
+    flex: 1 1 auto;
+    min-width: 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- center the "Book another evening" action within the confirmation card
- let the confirmation button expand on small screens for a stable mobile layout

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68edc0aacd20832396c8feb87115f6d4