### PR TITLE
Improve dining seat map scale and layout

### DIFF
--- a/public/css/dining-reserve.css
+++ b/public/css/dining-reserve.css
@@ -352,6 +352,17 @@
   display: grid;
   gap: 1.25rem;
   align-items: stretch;
+  grid-template-areas:
+    'map'
+    'insights';
+}
+
+.reserve-seatmap-wrapper {
+  grid-area: map;
+}
+
+.reserve-seatinsights {
+  grid-area: insights;
 }
 
 .reserve-seatinsights {
@@ -841,7 +852,7 @@
   }
 
   .reserve-grid {
-    grid-template-columns: minmax(0, 1.6fr) minmax(16rem, 22rem);
+    grid-template-columns: minmax(0, 1.9fr) minmax(13rem, 18rem);
     align-items: stretch;
   }
 
@@ -850,17 +861,26 @@
   }
 
   .reserve-seatmap-layout {
-    grid-template-columns: minmax(0, 1.75fr) minmax(15rem, 20rem);
+    grid-template-columns: minmax(13rem, 16rem) minmax(0, 1fr);
+    grid-template-areas: 'insights map';
     gap: 1.5rem;
+  }
+
+  .reserve-seatmap-wrapper {
+    grid-area: map;
+  }
+
+  .reserve-seatinsights {
+    grid-area: insights;
   }
 }
 
 @media (min-width: 1200px) {
   .reserve-grid {
-    grid-template-columns: minmax(0, 1.85fr) minmax(18rem, 24rem);
+    grid-template-columns: minmax(0, 2.1fr) minmax(14rem, 20rem);
   }
 
   .reserve-seatmap-layout {
-    grid-template-columns: minmax(0, 2fr) minmax(18rem, 24rem);
+    grid-template-columns: minmax(14rem, 18rem) minmax(0, 1fr);
   }
 }

--- a/public/js/dining-reserve/ui.js
+++ b/public/js/dining-reserve/ui.js
@@ -58,6 +58,18 @@ const ZONE_DETAILS = {
         accent: '#ff9ec7',
         highlights: ['Resident mixologist nearby', 'Lush velvet acoustics for conversation'],
     },
+    'aurora-bar': {
+        name: 'Aurora bar',
+        description: 'Glowing bar-top tables with proximity to our signature cocktail program.',
+        accent: '#f7a664',
+        highlights: ['Fast access to mixologists', 'Vibrant energy from the bar team'],
+    },
+    'private-dining': {
+        name: 'Private dining suite',
+        description: 'Secluded alcove with draped entry and dedicated service captain.',
+        accent: '#9fa5ff',
+        highlights: ['Acoustically private', 'Dedicated sommelier pairing service'],
+    },
     terrace: {
         name: 'Celestial Terrace',
         description: 'Climate-controlled terrace edged by floating lanterns and fireglass.',
@@ -398,14 +410,14 @@ function renderSeatMap() {
         const maxy = Math.max(acc[3], table.y);
         return [minx, miny, maxx, maxy];
     }, [Infinity, Infinity, -Infinity, -Infinity]);
-    const paddingX = 100;
-    const paddingY = 100;
+    const paddingX = 120;
+    const paddingY = 120;
     const rawWidth = maxX - minX + paddingX * 2;
     const rawHeight = maxY - minY + paddingY * 2;
-    const MIN_DISPLAY_WIDTH = 360;
-    const MIN_DISPLAY_HEIGHT = 320;
-    const MAX_DISPLAY_WIDTH = 520;
-    const MAX_DISPLAY_HEIGHT = 420;
+    const MIN_DISPLAY_WIDTH = 420;
+    const MIN_DISPLAY_HEIGHT = 380;
+    const MAX_DISPLAY_WIDTH = 760;
+    const MAX_DISPLAY_HEIGHT = 600;
     let scale = 1;
     if (rawWidth > MAX_DISPLAY_WIDTH) {
         scale = Math.min(scale, MAX_DISPLAY_WIDTH / rawWidth);

--- a/src/data/dining.js
+++ b/src/data/dining.js
@@ -335,20 +335,28 @@ const diningStaff = [
 ];
 
 const diningSeats = [
-  { id: 'T1', label: 'T1', capacity: 3, zone: 'Atrium', status: 'available', x: 80, y: 120 },
-  { id: 'T2', label: 'T2', capacity: 2, zone: 'Atrium', status: 'available', x: 170, y: 120 },
-  { id: 'T3', label: 'T3', capacity: 2, zone: 'Atrium', status: 'available', x: 260, y: 120 },
-  { id: 'T4', label: 'T4', capacity: 4, zone: 'Atrium', status: 'available', x: 350, y: 120 },
-  { id: 'T5', label: 'T5', capacity: 4, zone: 'Observatory', status: 'available', x: 90, y: 220 },
-  { id: 'T6', label: 'T6', capacity: 6, zone: 'Observatory', status: 'held', x: 200, y: 220 },
-  { id: 'T7', label: 'T7', capacity: 4, zone: 'Observatory', status: 'available', x: 310, y: 220 },
-  { id: 'T8', label: 'T8', capacity: 2, zone: 'Observatory', status: 'reserved', x: 420, y: 220 },
-  { id: 'T9', label: 'T9', capacity: 2, zone: "Chef's Counter", status: 'available', x: 120, y: 320 },
-  { id: 'T10', label: 'T10', capacity: 2, zone: "Chef's Counter", status: 'available', x: 210, y: 320 },
-  { id: 'T11', label: 'T11', capacity: 5, zone: 'Solstice Lounge', status: 'available', x: 320, y: 320 },
-  { id: 'T12', label: 'T12', capacity: 6, zone: 'Solstice Lounge', status: 'available', x: 430, y: 320 },
-  { id: 'T13', label: 'T13', capacity: 4, zone: 'Celestial Terrace', status: 'available', x: 160, y: 420 },
-  { id: 'T14', label: 'T14', capacity: 4, zone: 'Celestial Terrace', status: 'available', x: 320, y: 420 }
+  { id: 'T1', label: 'T1', capacity: 2, zone: "Chef's Counter", status: 'available', x: 120, y: 80 },
+  { id: 'T2', label: 'T2', capacity: 2, zone: "Chef's Counter", status: 'available', x: 210, y: 80 },
+  { id: 'T3', label: 'T3', capacity: 2, zone: "Chef's Counter", status: 'available', x: 300, y: 80 },
+  { id: 'T4', label: 'T4', capacity: 2, zone: "Chef's Counter", status: 'available', x: 390, y: 80 },
+  { id: 'T5', label: 'T5', capacity: 4, zone: 'Main floor', status: 'available', x: 80, y: 180 },
+  { id: 'T6', label: 'T6', capacity: 4, zone: 'Main floor', status: 'available', x: 200, y: 180 },
+  { id: 'T7', label: 'T7', capacity: 4, zone: 'Main floor', status: 'available', x: 320, y: 180 },
+  { id: 'T8', label: 'T8', capacity: 4, zone: 'Main floor', status: 'available', x: 440, y: 180 },
+  { id: 'T9', label: 'T9', capacity: 2, zone: 'Main floor', status: 'available', x: 80, y: 270 },
+  { id: 'T10', label: 'T10', capacity: 6, zone: 'Main floor', status: 'held', x: 200, y: 270 },
+  { id: 'T11', label: 'T11', capacity: 2, zone: 'Main floor', status: 'available', x: 320, y: 270 },
+  { id: 'T12', label: 'T12', capacity: 6, zone: 'Main floor', status: 'reserved', x: 440, y: 270 },
+  { id: 'T13', label: 'T13', capacity: 4, zone: 'Celestial Terrace', status: 'available', x: 80, y: 360 },
+  { id: 'T14', label: 'T14', capacity: 4, zone: 'Celestial Terrace', status: 'available', x: 200, y: 360 },
+  { id: 'T15', label: 'T15', capacity: 4, zone: 'Celestial Terrace', status: 'available', x: 320, y: 360 },
+  { id: 'T16', label: 'T16', capacity: 4, zone: 'Celestial Terrace', status: 'available', x: 440, y: 360 },
+  { id: 'T17', label: 'T17', capacity: 8, zone: 'Solstice Lounge', status: 'available', x: 560, y: 220 },
+  { id: 'T18', label: 'T18', capacity: 6, zone: 'Solstice Lounge', status: 'available', x: 560, y: 320 },
+  { id: 'T19', label: 'T19', capacity: 8, zone: 'Private Dining', status: 'available', x: 560, y: 120 },
+  { id: 'T20', label: 'T20', capacity: 6, zone: 'Aurora Bar', status: 'available', x: 200, y: 450 },
+  { id: 'T21', label: 'T21', capacity: 4, zone: 'Aurora Bar', status: 'available', x: 320, y: 450 },
+  { id: 'T22', label: 'T22', capacity: 2, zone: 'Aurora Bar', status: 'available', x: 440, y: 450 }
 ];
 
 module.exports = {


### PR DESCRIPTION
## Summary
- enlarge the dining seat map canvas and reposition the insights panel so the spotlight tooltip now sits to the left of the picker
- tune seat map scaling limits and add zone metadata for the Aurora bar and private dining suite
- expand the seeded dining tables to provide a fuller, more realistic floor plan layout

## Testing
- npm run seed

------
https://chatgpt.com/codex/tasks/task_e_68edc181a6e08323b54306be19c5b917