### PR TITLE
Implement role-based admin hierarchy and directory API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,13 @@
 DATABASE_URL="postgresql://USER:PASSWORD@HOST:PORT/DATABASE?schema=public"
 HOTEL_JWT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\n...replace_with_real_key...\n-----END PUBLIC KEY-----\n"
 DINING_PORT=4000
+
+# Bootstrap administrator overrides (set unique secrets in production)
+SEED_GLOBAL_ADMIN_EMAIL="global.admin@example.com"
+SEED_GLOBAL_ADMIN_PASSWORD="change-me"
+SEED_SUPER_ADMIN_ONE_EMAIL="super.one@example.com"
+SEED_SUPER_ADMIN_ONE_PASSWORD="change-me"
+SEED_SUPER_ADMIN_TWO_EMAIL="super.two@example.com"
+SEED_SUPER_ADMIN_TWO_PASSWORD="change-me"
+SEED_SUPER_ADMIN_THREE_EMAIL="super.three@example.com"
+SEED_SUPER_ADMIN_THREE_PASSWORD="change-me"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,14 @@ npm run dev
 
 3. Visit `http://localhost:3000` for the hotel site. The dining experience lives at `/dining` and shares the same session token.
 
-Seeded credentials (password `skyhaven123`):
+Seeded administrator credentials (development only):
+
+- Global Admin — Celeste Arin (`global.admin@skyhaven.dev` / `SkyhavenGlobal!23`)
+- Super Admin — Orion Pax (`super.orion@skyhaven.dev` / `SuperNova!23`)
+- Super Admin — Lyric Hale (`super.lyric@skyhaven.dev` / `SuperAurora!23`)
+- Super Admin — Vela Quinn (`super.vela@skyhaven.dev` / `SuperCosmos!23`)
+
+Legacy staff accounts (password `skyhaven123`):
 
 - `astra@skyhaven.test` (admin)
 - `kael@skyhaven.test` (admin)

--- a/src/app.js
+++ b/src/app.js
@@ -24,6 +24,7 @@ const chatRoutes = require('./routes/chat');
 const adminRoutes = require('./routes/admin');
 const diningRoutes = require('./routes/dining');
 const adminDiningRoutes = require('./routes/adminDining');
+const adminApiRoutes = require('./routes/adminApi');
 
 const app = express();
 const isProd = process.env.NODE_ENV === 'production';
@@ -167,6 +168,8 @@ app.use((req, res, next) => {
   req.session.alerts = [];
   next();
 });
+
+app.use('/api/admin', adminApiRoutes);
 
 const buildLimiter = ({ windowMs, max, skipSuccessfulRequests = false, message }) => {
   const retryAfterSeconds = Math.ceil(windowMs / 1000);

--- a/src/auth/verifySession.ts
+++ b/src/auth/verifySession.ts
@@ -11,12 +11,14 @@ type JwtUserPayload = JwtPayload & {
   email?: string;
   name?: string;
   id?: string;
+  role?: string;
 };
 
 export interface AuthenticatedUser {
   id: string;
   email: string;
   name?: string | null;
+  role?: string | null;
 }
 
 declare module 'express-serve-static-core' {
@@ -83,6 +85,7 @@ export function verifySession(req: Request, res: Response, next: NextFunction): 
       id: userId,
       email: userEmail,
       name: payload.name ?? null,
+      role: typeof payload.role === 'string' ? payload.role : null,
     };
 
     next();

--- a/src/models/auditLogs.js
+++ b/src/models/auditLogs.js
@@ -1,0 +1,41 @@
+const { v4: uuidv4 } = require('uuid');
+const { getDb } = require('../db');
+
+const db = getDb();
+
+function coerceDetails(details) {
+  if (details == null) {
+    return null;
+  }
+  if (typeof details === 'string') {
+    return details;
+  }
+  try {
+    return JSON.stringify(details);
+  } catch (error) {
+    return null;
+  }
+}
+
+function recordAuditLog({ actorUserId, targetUserId, action, details }) {
+  if (!action) {
+    throw new Error('Audit action is required');
+  }
+  const entry = {
+    id: uuidv4(),
+    actorUserId: actorUserId || null,
+    targetUserId: targetUserId || null,
+    action,
+    details: coerceDetails(details),
+    createdAt: new Date().toISOString()
+  };
+  db.prepare(
+    `INSERT INTO audit_logs (id, actorUserId, targetUserId, action, details, createdAt)
+     VALUES (@id, @actorUserId, @targetUserId, @action, @details, @createdAt)`
+  ).run(entry);
+  return entry;
+}
+
+module.exports = {
+  recordAuditLog
+};

--- a/src/models/roles.js
+++ b/src/models/roles.js
@@ -1,0 +1,114 @@
+const { getDb } = require('../db');
+const { normalizeRole, Roles, ALL_PERMISSIONS, isValidPermission } = require('../utils/rbac');
+const { recordAuditLog } = require('./auditLogs');
+
+const db = getDb();
+
+function listRoles() {
+  const rows = db
+    .prepare('SELECT id, label, priority FROM roles ORDER BY priority DESC')
+    .all();
+  return rows.map((row) => ({
+    id: normalizeRole(row.id),
+    label: row.label,
+    priority: row.priority
+  }));
+}
+
+function getRoleById(roleId) {
+  const normalized = normalizeRole(roleId);
+  const row = db.prepare('SELECT id, label, priority FROM roles WHERE id = ?').get(normalized);
+  if (!row) {
+    return null;
+  }
+  return {
+    id: normalizeRole(row.id),
+    label: row.label,
+    priority: row.priority
+  };
+}
+
+function getRolePermissions(roleId) {
+  const normalized = normalizeRole(roleId);
+  const rows = db
+    .prepare('SELECT permission, allowed FROM role_permissions WHERE roleId = ?')
+    .all(normalized);
+  const map = new Map(rows.map((row) => [row.permission, Boolean(row.allowed)]));
+  const permissions = {};
+  ALL_PERMISSIONS.forEach((permission) => {
+    permissions[permission] = map.has(permission) ? map.get(permission) : false;
+  });
+  return permissions;
+}
+
+function setRolePermission({ roleId, permission, allowed, updatedByUserId }) {
+  const normalizedRole = normalizeRole(roleId);
+  if (!getRoleById(normalizedRole)) {
+    const error = new Error('Role not found');
+    error.status = 404;
+    throw error;
+  }
+  if (!isValidPermission(permission)) {
+    const error = new Error('Unknown permission');
+    error.status = 400;
+    throw error;
+  }
+  const nextAllowed = Boolean(allowed);
+  const now = new Date().toISOString();
+  const existing = db
+    .prepare('SELECT allowed FROM role_permissions WHERE roleId = ? AND permission = ?')
+    .get(normalizedRole, permission);
+  const previous = existing ? Boolean(existing.allowed) : false;
+
+  db.prepare(
+    `INSERT INTO role_permissions (roleId, permission, allowed, updatedAt, updatedByUserId)
+     VALUES (@roleId, @permission, @allowed, @updatedAt, @updatedByUserId)
+     ON CONFLICT(roleId, permission)
+     DO UPDATE SET allowed = excluded.allowed, updatedAt = excluded.updatedAt, updatedByUserId = excluded.updatedByUserId`
+  ).run({
+    roleId: normalizedRole,
+    permission,
+    allowed: nextAllowed ? 1 : 0,
+    updatedAt: now,
+    updatedByUserId: updatedByUserId || null
+  });
+
+  if (previous !== nextAllowed) {
+    recordAuditLog({
+      actorUserId: updatedByUserId || null,
+      targetUserId: null,
+      action: 'role_permission_updated',
+      details: {
+        roleId: normalizedRole,
+        permission,
+        oldValue: previous,
+        newValue: nextAllowed
+      }
+    });
+  }
+
+  return getRolePermissions(normalizedRole);
+}
+
+function canManageRole(actorRole, targetRole) {
+  const normalizedActor = normalizeRole(actorRole);
+  const normalizedTarget = normalizeRole(targetRole);
+  if (normalizedActor === Roles.GLOBAL_ADMIN) {
+    return normalizedTarget !== Roles.GLOBAL_ADMIN;
+  }
+  if (normalizedActor === Roles.SUPER_ADMIN) {
+    return [Roles.ADMIN, Roles.EMPLOYEE].includes(normalizedTarget);
+  }
+  if (normalizedActor === Roles.ADMIN) {
+    return normalizedTarget === Roles.EMPLOYEE;
+  }
+  return false;
+}
+
+module.exports = {
+  listRoles,
+  getRoleById,
+  getRolePermissions,
+  setRolePermission,
+  canManageRole
+};

--- a/src/routes/adminApi.js
+++ b/src/routes/adminApi.js
@@ -1,0 +1,228 @@
+const express = require('express');
+const Joi = require('joi');
+const {
+  requireRole,
+  Roles,
+  roleHigherThan,
+  normalizeRole,
+  getRolePriority
+} = require('../utils/rbac');
+const {
+  getAllUsers,
+  createSubAdmin,
+  listSubAdmins,
+  getUserById,
+  removeSubAdmin
+} = require('../models/users');
+const {
+  getRolePermissions,
+  setRolePermission,
+  listRoles
+} = require('../models/roles');
+const { recordAuditLog } = require('../models/auditLogs');
+
+const router = express.Router();
+
+const roleSummaryOrder = [Roles.GLOBAL_ADMIN, Roles.SUPER_ADMIN, Roles.ADMIN, Roles.EMPLOYEE];
+
+const subAdminSchema = Joi.object({
+  name: Joi.string().min(2).max(80).required(),
+  email: Joi.string().email({ tlds: { allow: false } }).required(),
+  password: Joi.string().min(8).max(128).required(),
+  role: Joi.string()
+    .valid(Roles.ADMIN, Roles.SUPER_ADMIN)
+    .required(),
+  department: Joi.string().max(120).allow(null, ''),
+  status: Joi.string().valid('active', 'suspended', 'terminated').default('active')
+});
+
+const permissionUpdateSchema = Joi.object({
+  permission: Joi.string().required(),
+  allowed: Joi.boolean().required()
+});
+
+router.use(requireRole(Roles.ADMIN));
+
+router.get('/directory', (req, res) => {
+  const users = getAllUsers();
+  const units = new Map();
+  const roleSummary = {};
+
+  users.forEach((user) => {
+    const departmentName = user.department?.trim() || 'Unassigned';
+    const key = departmentName.toLowerCase();
+    const current = units.get(key) || { name: departmentName, members: [] };
+    current.members.push({
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      role: user.role,
+      status: user.status || 'active'
+    });
+    units.set(key, current);
+    const normalizedRole = normalizeRole(user.role);
+    roleSummary[normalizedRole] = (roleSummary[normalizedRole] || 0) + 1;
+  });
+
+  const sortedUnits = Array.from(units.values())
+    .map((unit) => ({
+      ...unit,
+      members: unit.members.sort((a, b) => {
+        const priorityDiff = getRolePriority(b.role) - getRolePriority(a.role);
+        if (priorityDiff !== 0) return priorityDiff;
+        return a.name.localeCompare(b.name);
+      })
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const orderedSummary = roleSummaryOrder.reduce((acc, role) => {
+    if (roleSummary[role]) {
+      acc.push({ role, count: roleSummary[role] });
+    }
+    return acc;
+  }, []);
+
+  return res.json({
+    units: sortedUnits,
+    roleSummary: orderedSummary,
+    totalUsers: users.length,
+    generatedAt: new Date().toISOString()
+  });
+});
+
+router.get('/subadmins', requireRole(Roles.SUPER_ADMIN), (req, res) => {
+  const subAdmins = listSubAdmins();
+  const cache = new Map();
+  const enriched = subAdmins.map((user) => {
+    const role = normalizeRole(user.role);
+    if (!cache.has(role)) {
+      cache.set(role, getRolePermissions(role));
+    }
+    return {
+      ...user,
+      permissions: cache.get(role)
+    };
+  });
+  return res.json({ subAdmins: enriched });
+});
+
+router.post('/subadmins', requireRole(Roles.SUPER_ADMIN), (req, res) => {
+  const { error, value } = subAdminSchema.validate(req.body, { abortEarly: false, stripUnknown: true });
+  if (error) {
+    return res.status(400).json({ error: 'Invalid sub-admin payload', details: error.details.map((detail) => detail.message) });
+  }
+  const normalizedRole = normalizeRole(value.role);
+  const actorRole = normalizeRole(req.user.role);
+  if (normalizedRole === Roles.SUPER_ADMIN && actorRole !== Roles.GLOBAL_ADMIN) {
+    return res.status(403).json({ error: 'Only the Global Admin can create Super Admins.' });
+  }
+  if (normalizedRole === Roles.ADMIN && ![Roles.GLOBAL_ADMIN, Roles.SUPER_ADMIN].includes(actorRole)) {
+    return res.status(403).json({ error: 'Insufficient privileges to create an Admin account.' });
+  }
+  try {
+    const newUser = createSubAdmin({
+      name: value.name,
+      email: value.email,
+      password: value.password,
+      role: normalizedRole,
+      department: value.department,
+      status: value.status,
+      createdByUserId: req.user.id
+    });
+    recordAuditLog({
+      actorUserId: req.user.id,
+      targetUserId: newUser.id,
+      action: 'subadmin_created',
+      details: {
+        role: newUser.role,
+        department: newUser.department || null
+      }
+    });
+    const permissions = getRolePermissions(newUser.role);
+    return res.status(201).json({ subAdmin: { ...newUser, permissions } });
+  } catch (creationError) {
+    const status = creationError.status || 500;
+    return res.status(status).json({ error: creationError.message || 'Unable to create sub-admin' });
+  }
+});
+
+router.delete('/subadmins/:id', requireRole(Roles.SUPER_ADMIN), (req, res) => {
+  const targetId = String(req.params.id || '').trim();
+  if (!targetId) {
+    return res.status(400).json({ error: 'Sub-admin id is required' });
+  }
+  const actorRole = normalizeRole(req.user.role);
+  const target = getUserById(targetId);
+  if (!target) {
+    return res.status(404).json({ error: 'Sub-admin not found' });
+  }
+  if (target.id === req.user.id) {
+    return res.status(400).json({ error: 'You cannot change your own status.' });
+  }
+  const targetRole = normalizeRole(target.role);
+  if (![Roles.ADMIN, Roles.SUPER_ADMIN].includes(targetRole)) {
+    return res.status(400).json({ error: 'Only admin accounts can be terminated via this endpoint.' });
+  }
+  if (!roleHigherThan(actorRole, targetRole)) {
+    return res.status(403).json({ error: 'You do not have sufficient privileges to remove that account.' });
+  }
+  const previousStatus = target.status;
+  const updated = removeSubAdmin(targetId);
+  recordAuditLog({
+    actorUserId: req.user.id,
+    targetUserId: targetId,
+    action: 'subadmin_status_changed',
+    details: {
+      role: updated.role,
+      previousStatus,
+      newStatus: updated.status
+    }
+  });
+  const permissions = getRolePermissions(updated.role);
+  return res.json({ subAdmin: { ...updated, permissions } });
+});
+
+router.get('/roles', requireRole(Roles.SUPER_ADMIN), (_req, res) => {
+  const roles = listRoles().map((role) => ({
+    ...role,
+    permissions: getRolePermissions(role.id)
+  }));
+  return res.json({ roles });
+});
+
+router.get('/roles/:roleId/permissions', requireRole(Roles.SUPER_ADMIN), (req, res) => {
+  const roleId = normalizeRole(req.params.roleId);
+  if (!listRoles().some((role) => role.id === roleId)) {
+    return res.status(404).json({ error: 'Role not found' });
+  }
+  return res.json({ roleId, permissions: getRolePermissions(roleId) });
+});
+
+router.patch('/roles/:roleId/permissions', requireRole(Roles.SUPER_ADMIN), (req, res) => {
+  const { error, value } = permissionUpdateSchema.validate(req.body, { abortEarly: false, stripUnknown: true });
+  if (error) {
+    return res.status(400).json({ error: 'Invalid permission payload', details: error.details.map((detail) => detail.message) });
+  }
+  const targetRole = normalizeRole(req.params.roleId);
+  const actorRole = normalizeRole(req.user.role);
+  if (targetRole === Roles.GLOBAL_ADMIN) {
+    return res.status(403).json({ error: 'Global Admin permissions cannot be modified.' });
+  }
+  if (!roleHigherThan(actorRole, targetRole)) {
+    return res.status(403).json({ error: 'You cannot modify permissions for an equal or higher role.' });
+  }
+  try {
+    const permissions = setRolePermission({
+      roleId: targetRole,
+      permission: value.permission,
+      allowed: value.allowed,
+      updatedByUserId: req.user.id
+    });
+    return res.json({ roleId: targetRole, permissions });
+  } catch (updateError) {
+    const status = updateError.status || 500;
+    return res.status(status).json({ error: updateError.message || 'Unable to update permission' });
+  }
+});
+
+module.exports = router;

--- a/src/routes/payments.js
+++ b/src/routes/payments.js
@@ -10,12 +10,13 @@ const {
   updatePaymentStatus,
   createReversal
 } = require('../models/payments');
+const { roleAtLeast, Roles } = require('../utils/rbac');
 
 const router = express.Router();
 
 function assertOwnership(req, booking) {
   if (!booking) return false;
-  if (req.user.role === 'admin') return true;
+  if (req.user && roleAtLeast(req.user.role, Roles.ADMIN)) return true;
   return booking.userId === req.user.id;
 }
 

--- a/src/server.js
+++ b/src/server.js
@@ -26,6 +26,7 @@ const {
   releaseSeat: socketReleaseSeat
 } = require('./services/diningSeatLocks');
 const { getUserFromRequest } = require('./utils/jwt');
+const { roleAtLeast, Roles } = require('./utils/rbac');
 
 const server = http.createServer(app);
 function normalizeOrigin(origin) {
@@ -216,7 +217,7 @@ io.on('connection', (socket) => {
   emitUnreadUpdate(user.id);
 
   socket.on('admin:subscribe', (channel) => {
-    if (user.role !== 'admin') {
+    if (!roleAtLeast(user.role, Roles.ADMIN)) {
       return;
     }
     if (channel === 'inquiries') {

--- a/src/utils/jwt.js
+++ b/src/utils/jwt.js
@@ -1,6 +1,7 @@
 const jwt = require('jsonwebtoken');
 const cookie = require('cookie');
 const { DEFAULT_JWT_SECRET } = require('./jwtDefaults');
+const { normalizeRole, Roles } = require('./rbac');
 
 function parseCookies(req) {
   const header = req.headers?.cookie || req.request?.headers?.cookie;
@@ -57,7 +58,7 @@ function formatUserLike(userLike) {
     id,
     email: email || null,
     name: name || null,
-    role: role || 'guest'
+    role: normalizeRole(role || Roles.EMPLOYEE)
   };
 }
 
@@ -103,7 +104,7 @@ function issueSessionToken(res, user) {
     sub: user.id,
     email: user.email,
     name: user.name || null,
-    role: user.role || 'guest',
+    role: normalizeRole(user.role || Roles.EMPLOYEE),
   };
   const token = jwt.sign(payload, signing.key, {
     algorithm: signing.algorithm,

--- a/src/utils/rbac.js
+++ b/src/utils/rbac.js
@@ -1,0 +1,104 @@
+const Roles = Object.freeze({
+  GLOBAL_ADMIN: 'GLOBAL_ADMIN',
+  SUPER_ADMIN: 'SUPER_ADMIN',
+  ADMIN: 'ADMIN',
+  EMPLOYEE: 'EMPLOYEE'
+});
+
+const RolePriority = Object.freeze({
+  [Roles.EMPLOYEE]: 10,
+  [Roles.ADMIN]: 30,
+  [Roles.SUPER_ADMIN]: 40,
+  [Roles.GLOBAL_ADMIN]: 50
+});
+
+const Permissions = Object.freeze({
+  MANAGE_EMPLOYEES: 'manage:employees',
+  RESET_PASSWORDS: 'reset:passwords',
+  APPROVE_TRANSFERS: 'approve:transfers',
+  MANAGE_PERMISSIONS: 'manage:permissions'
+});
+
+const ALL_PERMISSIONS = Object.freeze(Object.values(Permissions));
+
+function normalizeRole(role) {
+  if (!role || typeof role !== 'string') {
+    return Roles.EMPLOYEE;
+  }
+  const upper = role.trim().toUpperCase();
+  if (Roles[upper]) {
+    return Roles[upper];
+  }
+  const match = Object.values(Roles).find((value) => value === upper);
+  return match || Roles.EMPLOYEE;
+}
+
+function getRolePriority(role) {
+  const normalized = normalizeRole(role);
+  return RolePriority[normalized] || 0;
+}
+
+function roleAtLeast(role, minimumRole) {
+  return getRolePriority(role) >= getRolePriority(minimumRole);
+}
+
+function roleHigherThan(role, otherRole) {
+  return getRolePriority(role) > getRolePriority(otherRole);
+}
+
+function isValidPermission(permission) {
+  if (!permission || typeof permission !== 'string') {
+    return false;
+  }
+  return ALL_PERMISSIONS.includes(permission);
+}
+
+function buildUnauthorizedResponse(req, res) {
+  if (req.originalUrl && req.originalUrl.startsWith('/api')) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  if (req.session) {
+    req.session.returnTo = req.originalUrl;
+  }
+  if (typeof req.pushAlert === 'function') {
+    req.pushAlert('warning', 'Please log in to continue your Skyhaven journey.');
+  }
+  return res.redirect('/login');
+}
+
+function buildForbiddenResponse(req, res, message) {
+  if (req.originalUrl && req.originalUrl.startsWith('/api')) {
+    return res.status(403).json({ error: message || 'Forbidden' });
+  }
+  if (typeof req.pushAlert === 'function') {
+    req.pushAlert('danger', message || 'You do not have the required privileges to access that area.');
+  }
+  return res.redirect('/dashboard');
+}
+
+function requireRole(minimumRole, options = {}) {
+  const minRoleNormalized = normalizeRole(minimumRole);
+  const forbiddenMessage = options.forbiddenMessage;
+  return function roleMiddleware(req, res, next) {
+    if (!req.user) {
+      return buildUnauthorizedResponse(req, res);
+    }
+    const userRole = normalizeRole(req.user.role);
+    if (!roleAtLeast(userRole, minRoleNormalized)) {
+      return buildForbiddenResponse(req, res, forbiddenMessage);
+    }
+    return next();
+  };
+}
+
+module.exports = {
+  Roles,
+  Permissions,
+  ALL_PERMISSIONS,
+  normalizeRole,
+  getRolePriority,
+  roleAtLeast,
+  roleHigherThan,
+  isValidPermission,
+  requireRole
+};


### PR DESCRIPTION
## Summary
- introduce reusable RBAC utilities, role/permission models, and audit logging across the hotel stack
- seed global/super admin bootstrap accounts and expose admin APIs for directory lookups, sub-admin lifecycle, and permission tuning
- update middleware, JWT/session handling, and dining admin guards to honour hierarchical roles

## Testing
- npm run seed
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68edc4db9e5c8323b2a09fbecaba2e70