### PR TITLE
Add role-aware admin wizard and roster UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,13 @@
 DATABASE_URL="postgresql://USER:PASSWORD@HOST:PORT/DATABASE?schema=public"
 HOTEL_JWT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\n...replace_with_real_key...\n-----END PUBLIC KEY-----\n"
 DINING_PORT=4000
+
+# Bootstrap administrator overrides (set unique secrets in production)
+SEED_GLOBAL_ADMIN_EMAIL="global.admin@example.com"
+SEED_GLOBAL_ADMIN_PASSWORD="change-me"
+SEED_SUPER_ADMIN_ONE_EMAIL="super.one@example.com"
+SEED_SUPER_ADMIN_ONE_PASSWORD="change-me"
+SEED_SUPER_ADMIN_TWO_EMAIL="super.two@example.com"
+SEED_SUPER_ADMIN_TWO_PASSWORD="change-me"
+SEED_SUPER_ADMIN_THREE_EMAIL="super.three@example.com"
+SEED_SUPER_ADMIN_THREE_PASSWORD="change-me"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,14 @@ npm run dev
 
 3. Visit `http://localhost:3000` for the hotel site. The dining experience lives at `/dining` and shares the same session token.
 
-Seeded credentials (password `skyhaven123`):
+Seeded administrator credentials (development only):
+
+- Global Admin — Celeste Arin (`global.admin@skyhaven.dev` / `SkyhavenGlobal!23`)
+- Super Admin — Orion Pax (`super.orion@skyhaven.dev` / `SuperNova!23`)
+- Super Admin — Lyric Hale (`super.lyric@skyhaven.dev` / `SuperAurora!23`)
+- Super Admin — Vela Quinn (`super.vela@skyhaven.dev` / `SuperCosmos!23`)
+
+Legacy staff accounts (password `skyhaven123`):
 
 - `astra@skyhaven.test` (admin)
 - `kael@skyhaven.test` (admin)

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1170,6 +1170,261 @@ textarea:focus {
   gap: 1.6rem;
 }
 
+.admin-access-panel {
+  gap: 1.5rem;
+}
+
+.admin-access-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+}
+
+.admin-access-subtitle {
+  margin: 0.35rem 0 0;
+  color: rgba(226, 234, 255, 0.7);
+  font-size: 0.9rem;
+}
+
+.admin-access-copy {
+  font-size: 0.95rem;
+  color: rgba(226, 234, 255, 0.85);
+}
+
+.admin-access-hint {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+  margin: 0;
+}
+
+.admin-access-note {
+  padding: 1rem 1.2rem;
+  background: rgba(12, 24, 40, 0.65);
+  border: 1px dashed rgba(94, 252, 255, 0.22);
+  border-radius: 16px;
+}
+
+.role-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  border-radius: 999px;
+  padding: 0.45rem 1.1rem;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  background: rgba(12, 24, 40, 0.7);
+  border: 1px solid rgba(94, 252, 255, 0.35);
+  color: rgba(226, 234, 255, 0.92);
+}
+
+.role-badge__label {
+  font-weight: 600;
+}
+
+.role-badge--global_admin {
+  border-color: rgba(255, 196, 87, 0.6);
+}
+
+.role-badge--super_admin {
+  border-color: rgba(94, 252, 255, 0.6);
+}
+
+.role-badge--admin {
+  border-color: rgba(94, 252, 255, 0.3);
+}
+
+.subadmin-wizard {
+  display: grid;
+  gap: 1.4rem;
+  background: rgba(12, 24, 40, 0.55);
+  border: 1px solid rgba(94, 252, 255, 0.18);
+  border-radius: 18px;
+  padding: 1.6rem;
+}
+
+.subadmin-wizard__stage {
+  display: grid;
+  gap: 1.1rem;
+}
+
+.subadmin-wizard__stage[hidden] {
+  display: none;
+}
+
+.subadmin-wizard__roles {
+  display: grid;
+  gap: 0.75rem;
+}
+
+@media (min-width: 640px) {
+  .subadmin-wizard__roles {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+}
+
+.subadmin-role {
+  display: grid;
+  gap: 0.35rem;
+  text-align: left;
+  padding: 1rem 1.2rem;
+  border-radius: 16px;
+  border: 1px solid rgba(94, 252, 255, 0.22);
+  background: rgba(10, 16, 28, 0.65);
+  color: rgba(226, 234, 255, 0.9);
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+  cursor: pointer;
+}
+
+.subadmin-role:hover,
+.subadmin-role:focus-visible {
+  border-color: rgba(94, 252, 255, 0.45);
+  background: rgba(12, 24, 40, 0.85);
+  transform: translateY(-2px);
+}
+
+.subadmin-role.is-selected {
+  border-color: rgba(94, 252, 255, 0.7);
+  background: rgba(94, 252, 255, 0.1);
+  box-shadow: 0 0 18px rgba(94, 252, 255, 0.12);
+}
+
+.subadmin-role__label {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.subadmin-role__detail {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.subadmin-wizard__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.subadmin-form-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 640px) {
+  .subadmin-form-grid {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+}
+
+.subadmin-field {
+  display: grid;
+  gap: 0.45rem;
+  font-size: 0.9rem;
+}
+
+.subadmin-field__label {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-muted);
+}
+
+.subadmin-field__hint {
+  font-size: 0.75rem;
+  color: var(--color-muted);
+}
+
+.subadmin-field input {
+  background: rgba(12, 24, 40, 0.6);
+  border: 1px solid rgba(94, 252, 255, 0.18);
+  border-radius: 12px;
+  padding: 0.65rem 0.75rem;
+  color: inherit;
+}
+
+.subadmin-field input:focus {
+  outline: none;
+  border-color: rgba(94, 252, 255, 0.45);
+  box-shadow: 0 0 0 3px rgba(94, 252, 255, 0.15);
+}
+
+.subadmin-feedback {
+  min-height: 1.2rem;
+  font-size: 0.85rem;
+  color: var(--color-danger);
+}
+
+.subadmin-feedback.is-success {
+  color: rgba(94, 252, 255, 0.9);
+}
+
+.subadmin-success {
+  display: grid;
+  gap: 0.6rem;
+  font-size: 0.95rem;
+  color: rgba(226, 234, 255, 0.88);
+}
+
+.subadmin-roster-panel {
+  gap: 1.2rem;
+}
+
+.subadmin-roster__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.subadmin-roster__feedback {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+  min-height: 1rem;
+}
+
+.subadmin-roster__feedback.is-error {
+  color: var(--color-danger);
+}
+
+.subadmin-roster__feedback.is-success {
+  color: rgba(94, 252, 255, 0.85);
+}
+
+.subadmin-table td {
+  vertical-align: top;
+}
+
+.role-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(94, 252, 255, 0.35);
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.status-chip.status-active {
+  border-color: rgba(94, 252, 255, 0.5);
+  background: rgba(94, 252, 255, 0.08);
+}
+
+.status-chip.status-suspended {
+  border-color: rgba(255, 196, 87, 0.65);
+  background: rgba(255, 196, 87, 0.12);
+}
+
+.status-chip.status-terminated {
+  border-color: rgba(255, 107, 154, 0.6);
+  background: rgba(255, 107, 154, 0.12);
+}
+
 .dining-console__header {
   display: flex;
   flex-wrap: wrap;

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -6,143 +6,597 @@
     });
   }
 
-  const inquiryList = document.querySelector('[data-inquiry-list]');
-  if (!inquiryList || typeof window.io !== 'function') {
-    return;
-  }
-
   const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '';
-  const badge = document.querySelector('[data-inquiry-badge]');
-  const badgeValue = badge?.querySelector('[data-inquiry-count]');
 
-  const parseCount = () => {
-    if (!badge) return 0;
-    const stored = badge.getAttribute('data-open-count');
-    const fromText = badgeValue?.textContent?.trim();
-    const candidate = Number.parseInt(stored ?? fromText ?? '0', 10);
-    return Number.isNaN(candidate) ? 0 : candidate;
+  const roleLabels = {
+    GLOBAL_ADMIN: 'Global Admin',
+    SUPER_ADMIN: 'Super Admin',
+    ADMIN: 'Admin',
+    EMPLOYEE: 'Employee'
   };
 
-  const updateBadge = (next) => {
-    if (!badge || !badgeValue) return;
-    const safe = Math.max(0, next);
-    badge.setAttribute('data-open-count', String(safe));
-    badgeValue.textContent = String(safe);
+  const permissionLabels = {
+    'manage:employees': 'Manage employees',
+    'reset:passwords': 'Reset passwords',
+    'approve:transfers': 'Approve transfers',
+    'manage:permissions': 'Manage permissions'
   };
 
-  const formatTimestamp = (iso) => {
-    try {
-      return new Date(iso).toLocaleString('en-US', {
-        month: 'short',
-        day: 'numeric',
-        hour: '2-digit',
-        minute: '2-digit'
+  const escapeSelector = (value) => {
+    const stringValue = String(value ?? '');
+    if (window.CSS && typeof window.CSS.escape === 'function') {
+      return window.CSS.escape(stringValue);
+    }
+    return stringValue.replace(/"/g, '\\"');
+  };
+
+  const initSubAdminRoster = () => {
+    const section = document.querySelector('[data-subadmin-roster]');
+    if (!section) {
+      return {
+        refresh: () => {},
+        upsert: () => {}
+      };
+    }
+
+    const tableBody = section.querySelector('[data-roster-body]');
+    const feedback = section.querySelector('[data-roster-feedback]');
+    const refreshButton = section.querySelector('[data-roster-refresh]');
+    const emptyMessage = section.getAttribute('data-empty-text') || 'No delegated administrators yet.';
+
+    const setFeedback = (message, tone = 'info') => {
+      if (!feedback) return;
+      const text = message || '';
+      feedback.textContent = text;
+      feedback.classList.remove('is-error', 'is-success');
+      if (!text) {
+        return;
+      }
+      if (tone === 'error') {
+        feedback.classList.add('is-error');
+      } else if (tone === 'success') {
+        feedback.classList.add('is-success');
+      }
+    };
+
+    const clearBody = () => {
+      if (!tableBody) return;
+      while (tableBody.firstChild) {
+        tableBody.removeChild(tableBody.firstChild);
+      }
+    };
+
+    const showEmpty = () => {
+      if (!tableBody) return;
+      clearBody();
+      const row = document.createElement('tr');
+      row.dataset.rosterEmpty = 'true';
+      const cell = document.createElement('td');
+      cell.colSpan = 5;
+      cell.className = 'muted';
+      cell.textContent = emptyMessage;
+      row.append(cell);
+      tableBody.append(row);
+    };
+
+    const renderPermissions = (permissions) => {
+      if (!Array.isArray(permissions) || !permissions.length) {
+        const placeholder = document.createElement('span');
+        placeholder.className = 'muted';
+        placeholder.textContent = 'Default privileges';
+        return placeholder;
+      }
+      const list = document.createElement('ul');
+      list.className = 'chip-list';
+      permissions.forEach((permission) => {
+        const item = document.createElement('li');
+        item.textContent = permissionLabels[permission] || permission;
+        list.append(item);
       });
+      return list;
+    };
+
+    const renderRow = (record) => {
+      const row = document.createElement('tr');
+      row.dataset.subadminId = record.id;
+
+      const identityCell = document.createElement('td');
+      const stack = document.createElement('div');
+      stack.className = 'stacked';
+      const nameEl = document.createElement('strong');
+      nameEl.textContent = record.name || record.email || 'Admin';
+      const emailEl = document.createElement('span');
+      emailEl.className = 'muted';
+      emailEl.textContent = record.email || '—';
+      stack.append(nameEl, emailEl);
+      identityCell.append(stack);
+
+      const roleCell = document.createElement('td');
+      const roleChip = document.createElement('span');
+      roleChip.className = 'role-chip';
+      roleChip.textContent = roleLabels[record.role] || record.role || 'Admin';
+      roleCell.append(roleChip);
+
+      const departmentCell = document.createElement('td');
+      if (record.department) {
+        departmentCell.textContent = record.department;
+      } else {
+        departmentCell.className = 'muted';
+        departmentCell.textContent = '—';
+      }
+
+      const statusCell = document.createElement('td');
+      const statusValue = String(record.status || 'active').toLowerCase();
+      const statusChip = document.createElement('span');
+      statusChip.className = `status-chip status-${statusValue}`;
+      statusChip.textContent = statusValue.charAt(0).toUpperCase() + statusValue.slice(1);
+      statusCell.append(statusChip);
+
+      const permissionsCell = document.createElement('td');
+      permissionsCell.append(renderPermissions(record.permissions));
+
+      row.append(identityCell, roleCell, departmentCell, statusCell, permissionsCell);
+      return row;
+    };
+
+    const upsert = (record) => {
+      if (!tableBody || !record || !record.id) {
+        return;
+      }
+      const safeId = escapeSelector(record.id);
+      const existing = tableBody.querySelector(`[data-subadmin-id="${safeId}"]`);
+      const nextRow = renderRow(record);
+      const emptyRow = tableBody.querySelector('[data-roster-empty]');
+      if (emptyRow) {
+        emptyRow.remove();
+      }
+      if (existing) {
+        existing.replaceWith(nextRow);
+      } else {
+        tableBody.prepend(nextRow);
+      }
+    };
+
+    const refresh = async () => {
+      if (!tableBody) return;
+      clearBody();
+      const loadingRow = document.createElement('tr');
+      loadingRow.dataset.rosterLoading = 'true';
+      const cell = document.createElement('td');
+      cell.colSpan = 5;
+      cell.textContent = 'Loading delegated administrators…';
+      loadingRow.append(cell);
+      tableBody.append(loadingRow);
+      setFeedback('');
+      try {
+        const response = await fetch('/api/admin/subadmins', {
+          headers: { Accept: 'application/json' },
+          credentials: 'same-origin'
+        });
+        const payload = await response.json().catch(() => ({}));
+        if (!response.ok) {
+          throw new Error(payload.error || 'Unable to load delegated admins.');
+        }
+        const records = Array.isArray(payload.subAdmins) ? payload.subAdmins : [];
+        clearBody();
+        if (!records.length) {
+          showEmpty();
+          setFeedback('No delegated administrators yet.', 'info');
+          return;
+        }
+        records
+          .sort((a, b) => {
+            const nameA = String(a.name || a.email || '').toLowerCase();
+            const nameB = String(b.name || b.email || '').toLowerCase();
+            if (nameA < nameB) return -1;
+            if (nameA > nameB) return 1;
+            return 0;
+          })
+          .forEach((record) => {
+            tableBody.append(renderRow(record));
+          });
+        setFeedback(`Showing ${records.length} delegated ${records.length === 1 ? 'admin' : 'admins'}.`, 'success');
+      } catch (error) {
+        clearBody();
+        showEmpty();
+        setFeedback(error.message || 'Unable to load delegated admins.', 'error');
+      }
+    };
+
+    if (refreshButton) {
+      refreshButton.addEventListener('click', () => {
+        refresh();
+      });
+    }
+
+    refresh();
+
+    return {
+      refresh,
+      upsert
+    };
+  };
+
+  const initSubAdminWizard = (rosterApi) => {
+    const wizard = document.querySelector('[data-subadmin-wizard]');
+    if (!wizard) return;
+
+    let config = {};
+    try {
+      const rawConfig = wizard.getAttribute('data-config');
+      if (rawConfig) {
+        config = JSON.parse(rawConfig);
+      }
     } catch (error) {
-      return iso;
+      console.warn('Unable to parse sub-admin wizard configuration', error);
+    }
+
+    const allowedRoles = Array.isArray(config.allowedSubAdminRoles) ? config.allowedSubAdminRoles : [];
+    if (!allowedRoles.length) {
+      return;
+    }
+
+    const stages = {
+      select: wizard.querySelector('[data-stage="select"]'),
+      details: wizard.querySelector('[data-stage="details"]'),
+      result: wizard.querySelector('[data-stage="result"]')
+    };
+    const continueButton = wizard.querySelector('[data-action="advance"]');
+    const backButton = wizard.querySelector('[data-action="back"]');
+    const finishButton = wizard.querySelector('[data-action="finish-wizard"]');
+    const createAnotherButton = wizard.querySelector('[data-action="create-another"]');
+    const form = wizard.querySelector('[data-subadmin-form]');
+    const feedback = wizard.querySelector('[data-subadmin-feedback]');
+    const roleInput = wizard.querySelector('[data-role-input]');
+    const submitButton = wizard.querySelector('[data-action="submit"]');
+    const resultName = wizard.querySelector('[data-result-name]');
+    const resultRole = wizard.querySelector('[data-result-role]');
+    const roleButtons = Array.from(wizard.querySelectorAll('[data-role-option]'));
+    const selectedRoleLabels = wizard.querySelectorAll('[data-selected-role-label]');
+
+    let selectedRole = '';
+
+    const setSelectedRoleLabel = (role) => {
+      const label = roleLabels[role] || role || 'Admin';
+      selectedRoleLabels.forEach((node) => {
+        node.textContent = label;
+      });
+    };
+
+    const showStage = (name) => {
+      Object.entries(stages).forEach(([key, stage]) => {
+        if (!stage) return;
+        stage.hidden = key !== name;
+      });
+      if (feedback) {
+        feedback.textContent = '';
+        feedback.classList.remove('is-success', 'is-error');
+      }
+    };
+
+    const focusNameField = () => {
+      const nameInput = form?.querySelector('input[name="name"]');
+      if (nameInput) {
+        nameInput.focus();
+      }
+    };
+
+    const selectRole = (role) => {
+      selectedRole = role;
+      if (roleInput) {
+        roleInput.value = role;
+      }
+      setSelectedRoleLabel(role);
+      roleButtons.forEach((button) => {
+        if (button.dataset.role === role) {
+          button.classList.add('is-selected');
+          button.setAttribute('aria-pressed', 'true');
+        } else {
+          button.classList.remove('is-selected');
+          button.setAttribute('aria-pressed', 'false');
+        }
+      });
+      if (continueButton) {
+        continueButton.disabled = !role;
+      }
+      if (submitButton) {
+        submitButton.disabled = !role;
+      }
+    };
+
+    roleButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        selectRole(button.dataset.role || '');
+      });
+    });
+
+    if (continueButton) {
+      continueButton.addEventListener('click', () => {
+        if (!selectedRole) return;
+        showStage('details');
+        focusNameField();
+      });
+    }
+
+    if (backButton) {
+      backButton.addEventListener('click', () => {
+        showStage('select');
+      });
+    }
+
+    const startOver = (preserveRole = false) => {
+      form?.reset();
+      if (!preserveRole) {
+        selectRole('');
+        showStage('select');
+        return;
+      }
+      if (!selectedRole && allowedRoles.length) {
+        selectRole(allowedRoles[0]);
+      }
+      showStage('details');
+      focusNameField();
+    };
+
+    if (finishButton) {
+      finishButton.addEventListener('click', () => {
+        startOver(false);
+      });
+    }
+
+    if (createAnotherButton) {
+      createAnotherButton.addEventListener('click', () => {
+        startOver(true);
+      });
+    }
+
+    const validatePayload = (payload) => {
+      if (!payload.name) {
+        return 'Please provide the new administrator\'s name.';
+      }
+      if (!payload.email) {
+        return 'Please provide an email address.';
+      }
+      if (!payload.password || payload.password.length < 8) {
+        return 'Temporary passwords must be at least 8 characters long.';
+      }
+      return '';
+    };
+
+    if (form) {
+      form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (!selectedRole) {
+          if (feedback) {
+            feedback.textContent = 'Select a role to continue.';
+            feedback.classList.remove('is-success');
+            feedback.classList.add('is-error');
+          }
+          return;
+        }
+
+        const formData = new FormData(form);
+        const payload = {
+          role: selectedRole,
+          name: formData.get('name')?.toString().trim() || '',
+          email: formData.get('email')?.toString().trim() || '',
+          password: formData.get('password')?.toString() || '',
+          department: formData.get('department')?.toString().trim() || ''
+        };
+        payload.department = payload.department || null;
+
+        const validationError = validatePayload(payload);
+        if (validationError) {
+          if (feedback) {
+            feedback.textContent = validationError;
+            feedback.classList.remove('is-success');
+            feedback.classList.add('is-error');
+          }
+          return;
+        }
+
+        if (feedback) {
+          feedback.textContent = '';
+          feedback.classList.remove('is-success', 'is-error');
+        }
+        if (submitButton) {
+          submitButton.disabled = true;
+          submitButton.dataset.loading = 'true';
+        }
+
+        try {
+          const response = await fetch('/api/admin/subadmins', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Accept: 'application/json',
+              'X-CSRF-Token': csrfToken
+            },
+            credentials: 'same-origin',
+            body: JSON.stringify(payload)
+          });
+          const data = await response.json().catch(() => ({}));
+          if (!response.ok) {
+            throw new Error(data.error || 'Unable to create sub-admin.');
+          }
+
+          const created = data.subAdmin || {};
+          if (resultName) {
+            resultName.textContent = created.name || payload.name || 'New admin';
+          }
+          if (resultRole) {
+            const label = roleLabels[created.role] || roleLabels[payload.role] || payload.role;
+            resultRole.textContent = label;
+          }
+          if (typeof rosterApi?.upsert === 'function' && created.id) {
+            rosterApi.upsert(created);
+          }
+          showStage('result');
+          if (feedback) {
+            feedback.textContent = '';
+          }
+        } catch (error) {
+          if (feedback) {
+            feedback.textContent = error.message || 'Something went wrong while creating the account.';
+            feedback.classList.remove('is-success');
+            feedback.classList.add('is-error');
+          }
+        } finally {
+          if (submitButton) {
+            submitButton.disabled = false;
+            delete submitButton.dataset.loading;
+          }
+        }
+      });
+    }
+
+    if (allowedRoles.length === 1) {
+      selectRole(allowedRoles[0]);
     }
   };
 
-  const createHiddenInput = (name, value) => {
-    const input = document.createElement('input');
-    input.type = 'hidden';
-    input.name = name;
-    input.value = value;
-    return input;
+  const initInquiries = () => {
+    const inquiryList = document.querySelector('[data-inquiry-list]');
+    if (!inquiryList || typeof window.io !== 'function') {
+      return;
+    }
+
+    const badge = document.querySelector('[data-inquiry-badge]');
+    const badgeValue = badge?.querySelector('[data-inquiry-count]');
+
+    const parseCount = () => {
+      if (!badge) return 0;
+      const stored = badge.getAttribute('data-open-count');
+      const fromText = badgeValue?.textContent?.trim();
+      const candidate = Number.parseInt(stored ?? fromText ?? '0', 10);
+      return Number.isNaN(candidate) ? 0 : candidate;
+    };
+
+    const updateBadge = (next) => {
+      if (!badge || !badgeValue) return;
+      const safe = Math.max(0, next);
+      badge.setAttribute('data-open-count', String(safe));
+      badgeValue.textContent = String(safe);
+    };
+
+    const formatTimestamp = (iso) => {
+      try {
+        return new Date(iso).toLocaleString('en-US', {
+          month: 'short',
+          day: 'numeric',
+          hour: '2-digit',
+          minute: '2-digit'
+        });
+      } catch (error) {
+        return iso;
+      }
+    };
+
+    const createHiddenInput = (name, value) => {
+      const input = document.createElement('input');
+      input.type = 'hidden';
+      input.name = name;
+      input.value = value;
+      return input;
+    };
+
+    const renderInquiry = (inquiry) => {
+      const card = document.createElement('li');
+      card.className = 'inquiry-card';
+      card.dataset.inquiryId = inquiry.id;
+      if (inquiry.status === 'resolved') {
+        card.classList.add('is-resolved');
+      } else {
+        card.classList.add('is-new');
+      }
+
+      const header = document.createElement('header');
+      header.className = 'inquiry-header';
+
+      const stack = document.createElement('div');
+      stack.className = 'stacked';
+
+      const nameEl = document.createElement('strong');
+      nameEl.textContent = inquiry.name;
+      const emailEl = document.createElement('span');
+      emailEl.className = 'muted';
+      emailEl.textContent = inquiry.email;
+
+      stack.append(nameEl, emailEl);
+
+      const statusChip = document.createElement('span');
+      statusChip.className = `status-chip status-${inquiry.status}`;
+      statusChip.textContent = inquiry.status;
+
+      header.append(stack, statusChip);
+
+      const message = document.createElement('p');
+      message.textContent = inquiry.message;
+
+      const footer = document.createElement('footer');
+      footer.className = 'inquiry-footer';
+
+      const meta = document.createElement('small');
+      meta.className = 'muted';
+      meta.textContent = `Received ${formatTimestamp(inquiry.receivedAt)}`;
+      if (inquiry.status === 'resolved' && inquiry.resolvedAt) {
+        meta.textContent += ` • Resolved ${formatTimestamp(inquiry.resolvedAt)}`;
+      }
+
+      const form = document.createElement('form');
+      form.className = 'inline-form';
+      form.method = 'post';
+      form.action = `/admin/inquiries/${inquiry.id}/status`;
+      form.append(createHiddenInput('_csrf', csrfToken));
+      form.append(createHiddenInput('status', inquiry.status === 'resolved' ? 'open' : 'resolved'));
+
+      const button = document.createElement('button');
+      button.type = 'submit';
+      button.className = `pill-link ${inquiry.status === 'resolved' ? 'secondary' : 'primary'}`;
+      button.textContent = inquiry.status === 'resolved' ? 'Reopen' : 'Mark resolved';
+
+      form.append(button);
+      footer.append(meta, form);
+
+      card.append(header, message, footer);
+      return card;
+    };
+
+    const removeEmptyState = () => {
+      const empty = inquiryList.querySelector('[data-empty]');
+      if (empty) {
+        empty.remove();
+      }
+    };
+
+    const socket = window.io(window.location.origin, {
+      path: '/socket.io',
+      transports: ['websocket', 'polling']
+    });
+
+    socket.on('connect', () => {
+      socket.emit('admin:subscribe', 'inquiries');
+    });
+
+    socket.on('inquiry:new', (inquiry) => {
+      removeEmptyState();
+      const card = renderInquiry(inquiry);
+      inquiryList.prepend(card);
+      const current = parseCount();
+      if (inquiry.status !== 'resolved') {
+        updateBadge(current + 1);
+      }
+      card.addEventListener(
+        'animationend',
+        () => {
+          card.classList.remove('is-new');
+        },
+        { once: true }
+      );
+    });
   };
 
-  const renderInquiry = (inquiry) => {
-    const card = document.createElement('li');
-    card.className = 'inquiry-card';
-    card.dataset.inquiryId = inquiry.id;
-    if (inquiry.status === 'resolved') {
-      card.classList.add('is-resolved');
-    } else {
-      card.classList.add('is-new');
-    }
-
-    const header = document.createElement('header');
-    header.className = 'inquiry-header';
-
-    const stack = document.createElement('div');
-    stack.className = 'stacked';
-
-    const nameEl = document.createElement('strong');
-    nameEl.textContent = inquiry.name;
-    const emailEl = document.createElement('span');
-    emailEl.className = 'muted';
-    emailEl.textContent = inquiry.email;
-
-    stack.append(nameEl, emailEl);
-
-    const statusChip = document.createElement('span');
-    statusChip.className = `status-chip status-${inquiry.status}`;
-    statusChip.textContent = inquiry.status;
-
-    header.append(stack, statusChip);
-
-    const message = document.createElement('p');
-    message.textContent = inquiry.message;
-
-    const footer = document.createElement('footer');
-    footer.className = 'inquiry-footer';
-
-    const meta = document.createElement('small');
-    meta.className = 'muted';
-    meta.textContent = `Received ${formatTimestamp(inquiry.receivedAt)}`;
-    if (inquiry.status === 'resolved' && inquiry.resolvedAt) {
-      meta.textContent += ` • Resolved ${formatTimestamp(inquiry.resolvedAt)}`;
-    }
-
-    const form = document.createElement('form');
-    form.className = 'inline-form';
-    form.method = 'post';
-    form.action = `/admin/inquiries/${inquiry.id}/status`;
-    form.append(createHiddenInput('_csrf', csrfToken));
-    form.append(createHiddenInput('status', inquiry.status === 'resolved' ? 'open' : 'resolved'));
-
-    const button = document.createElement('button');
-    button.type = 'submit';
-    button.className = `pill-link ${inquiry.status === 'resolved' ? 'secondary' : 'primary'}`;
-    button.textContent = inquiry.status === 'resolved' ? 'Reopen' : 'Mark resolved';
-
-    form.append(button);
-    footer.append(meta, form);
-
-    card.append(header, message, footer);
-    return card;
-  };
-
-  const removeEmptyState = () => {
-    const empty = inquiryList.querySelector('[data-empty]');
-    if (empty) {
-      empty.remove();
-    }
-  };
-
-  const socket = window.io(window.location.origin, {
-    path: '/socket.io',
-    transports: ['websocket', 'polling']
-  });
-
-  socket.on('connect', () => {
-    socket.emit('admin:subscribe', 'inquiries');
-  });
-
-  socket.on('inquiry:new', (inquiry) => {
-    removeEmptyState();
-    const card = renderInquiry(inquiry);
-    inquiryList.prepend(card);
-    const current = parseCount();
-    if (inquiry.status !== 'resolved') {
-      updateBadge(current + 1);
-    }
-    card.addEventListener(
-      'animationend',
-      () => {
-        card.classList.remove('is-new');
-      },
-      { once: true }
-    );
-  });
+  const rosterApi = initSubAdminRoster();
+  initSubAdminWizard(rosterApi);
+  initInquiries();
 })();

--- a/src/app.js
+++ b/src/app.js
@@ -24,6 +24,7 @@ const chatRoutes = require('./routes/chat');
 const adminRoutes = require('./routes/admin');
 const diningRoutes = require('./routes/dining');
 const adminDiningRoutes = require('./routes/adminDining');
+const adminApiRoutes = require('./routes/adminApi');
 
 const app = express();
 const isProd = process.env.NODE_ENV === 'production';
@@ -167,6 +168,8 @@ app.use((req, res, next) => {
   req.session.alerts = [];
   next();
 });
+
+app.use('/api/admin', adminApiRoutes);
 
 const buildLimiter = ({ windowMs, max, skipSuccessfulRequests = false, message }) => {
   const retryAfterSeconds = Math.ceil(windowMs / 1000);

--- a/src/auth/verifySession.ts
+++ b/src/auth/verifySession.ts
@@ -11,12 +11,14 @@ type JwtUserPayload = JwtPayload & {
   email?: string;
   name?: string;
   id?: string;
+  role?: string;
 };
 
 export interface AuthenticatedUser {
   id: string;
   email: string;
   name?: string | null;
+  role?: string | null;
 }
 
 declare module 'express-serve-static-core' {
@@ -83,6 +85,7 @@ export function verifySession(req: Request, res: Response, next: NextFunction): 
       id: userId,
       email: userEmail,
       name: payload.name ?? null,
+      role: typeof payload.role === 'string' ? payload.role : null,
     };
 
     next();

--- a/src/models/auditLogs.js
+++ b/src/models/auditLogs.js
@@ -1,0 +1,41 @@
+const { v4: uuidv4 } = require('uuid');
+const { getDb } = require('../db');
+
+const db = getDb();
+
+function coerceDetails(details) {
+  if (details == null) {
+    return null;
+  }
+  if (typeof details === 'string') {
+    return details;
+  }
+  try {
+    return JSON.stringify(details);
+  } catch (error) {
+    return null;
+  }
+}
+
+function recordAuditLog({ actorUserId, targetUserId, action, details }) {
+  if (!action) {
+    throw new Error('Audit action is required');
+  }
+  const entry = {
+    id: uuidv4(),
+    actorUserId: actorUserId || null,
+    targetUserId: targetUserId || null,
+    action,
+    details: coerceDetails(details),
+    createdAt: new Date().toISOString()
+  };
+  db.prepare(
+    `INSERT INTO audit_logs (id, actorUserId, targetUserId, action, details, createdAt)
+     VALUES (@id, @actorUserId, @targetUserId, @action, @details, @createdAt)`
+  ).run(entry);
+  return entry;
+}
+
+module.exports = {
+  recordAuditLog
+};

--- a/src/models/roles.js
+++ b/src/models/roles.js
@@ -1,0 +1,114 @@
+const { getDb } = require('../db');
+const { normalizeRole, Roles, ALL_PERMISSIONS, isValidPermission } = require('../utils/rbac');
+const { recordAuditLog } = require('./auditLogs');
+
+const db = getDb();
+
+function listRoles() {
+  const rows = db
+    .prepare('SELECT id, label, priority FROM roles ORDER BY priority DESC')
+    .all();
+  return rows.map((row) => ({
+    id: normalizeRole(row.id),
+    label: row.label,
+    priority: row.priority
+  }));
+}
+
+function getRoleById(roleId) {
+  const normalized = normalizeRole(roleId);
+  const row = db.prepare('SELECT id, label, priority FROM roles WHERE id = ?').get(normalized);
+  if (!row) {
+    return null;
+  }
+  return {
+    id: normalizeRole(row.id),
+    label: row.label,
+    priority: row.priority
+  };
+}
+
+function getRolePermissions(roleId) {
+  const normalized = normalizeRole(roleId);
+  const rows = db
+    .prepare('SELECT permission, allowed FROM role_permissions WHERE roleId = ?')
+    .all(normalized);
+  const map = new Map(rows.map((row) => [row.permission, Boolean(row.allowed)]));
+  const permissions = {};
+  ALL_PERMISSIONS.forEach((permission) => {
+    permissions[permission] = map.has(permission) ? map.get(permission) : false;
+  });
+  return permissions;
+}
+
+function setRolePermission({ roleId, permission, allowed, updatedByUserId }) {
+  const normalizedRole = normalizeRole(roleId);
+  if (!getRoleById(normalizedRole)) {
+    const error = new Error('Role not found');
+    error.status = 404;
+    throw error;
+  }
+  if (!isValidPermission(permission)) {
+    const error = new Error('Unknown permission');
+    error.status = 400;
+    throw error;
+  }
+  const nextAllowed = Boolean(allowed);
+  const now = new Date().toISOString();
+  const existing = db
+    .prepare('SELECT allowed FROM role_permissions WHERE roleId = ? AND permission = ?')
+    .get(normalizedRole, permission);
+  const previous = existing ? Boolean(existing.allowed) : false;
+
+  db.prepare(
+    `INSERT INTO role_permissions (roleId, permission, allowed, updatedAt, updatedByUserId)
+     VALUES (@roleId, @permission, @allowed, @updatedAt, @updatedByUserId)
+     ON CONFLICT(roleId, permission)
+     DO UPDATE SET allowed = excluded.allowed, updatedAt = excluded.updatedAt, updatedByUserId = excluded.updatedByUserId`
+  ).run({
+    roleId: normalizedRole,
+    permission,
+    allowed: nextAllowed ? 1 : 0,
+    updatedAt: now,
+    updatedByUserId: updatedByUserId || null
+  });
+
+  if (previous !== nextAllowed) {
+    recordAuditLog({
+      actorUserId: updatedByUserId || null,
+      targetUserId: null,
+      action: 'role_permission_updated',
+      details: {
+        roleId: normalizedRole,
+        permission,
+        oldValue: previous,
+        newValue: nextAllowed
+      }
+    });
+  }
+
+  return getRolePermissions(normalizedRole);
+}
+
+function canManageRole(actorRole, targetRole) {
+  const normalizedActor = normalizeRole(actorRole);
+  const normalizedTarget = normalizeRole(targetRole);
+  if (normalizedActor === Roles.GLOBAL_ADMIN) {
+    return normalizedTarget !== Roles.GLOBAL_ADMIN;
+  }
+  if (normalizedActor === Roles.SUPER_ADMIN) {
+    return [Roles.ADMIN, Roles.EMPLOYEE].includes(normalizedTarget);
+  }
+  if (normalizedActor === Roles.ADMIN) {
+    return normalizedTarget === Roles.EMPLOYEE;
+  }
+  return false;
+}
+
+module.exports = {
+  listRoles,
+  getRoleById,
+  getRolePermissions,
+  setRolePermission,
+  canManageRole
+};

--- a/src/routes/adminApi.js
+++ b/src/routes/adminApi.js
@@ -1,0 +1,228 @@
+const express = require('express');
+const Joi = require('joi');
+const {
+  requireRole,
+  Roles,
+  roleHigherThan,
+  normalizeRole,
+  getRolePriority
+} = require('../utils/rbac');
+const {
+  getAllUsers,
+  createSubAdmin,
+  listSubAdmins,
+  getUserById,
+  removeSubAdmin
+} = require('../models/users');
+const {
+  getRolePermissions,
+  setRolePermission,
+  listRoles
+} = require('../models/roles');
+const { recordAuditLog } = require('../models/auditLogs');
+
+const router = express.Router();
+
+const roleSummaryOrder = [Roles.GLOBAL_ADMIN, Roles.SUPER_ADMIN, Roles.ADMIN, Roles.EMPLOYEE];
+
+const subAdminSchema = Joi.object({
+  name: Joi.string().min(2).max(80).required(),
+  email: Joi.string().email({ tlds: { allow: false } }).required(),
+  password: Joi.string().min(8).max(128).required(),
+  role: Joi.string()
+    .valid(Roles.ADMIN, Roles.SUPER_ADMIN)
+    .required(),
+  department: Joi.string().max(120).allow(null, ''),
+  status: Joi.string().valid('active', 'suspended', 'terminated').default('active')
+});
+
+const permissionUpdateSchema = Joi.object({
+  permission: Joi.string().required(),
+  allowed: Joi.boolean().required()
+});
+
+router.use(requireRole(Roles.ADMIN));
+
+router.get('/directory', (req, res) => {
+  const users = getAllUsers();
+  const units = new Map();
+  const roleSummary = {};
+
+  users.forEach((user) => {
+    const departmentName = user.department?.trim() || 'Unassigned';
+    const key = departmentName.toLowerCase();
+    const current = units.get(key) || { name: departmentName, members: [] };
+    current.members.push({
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      role: user.role,
+      status: user.status || 'active'
+    });
+    units.set(key, current);
+    const normalizedRole = normalizeRole(user.role);
+    roleSummary[normalizedRole] = (roleSummary[normalizedRole] || 0) + 1;
+  });
+
+  const sortedUnits = Array.from(units.values())
+    .map((unit) => ({
+      ...unit,
+      members: unit.members.sort((a, b) => {
+        const priorityDiff = getRolePriority(b.role) - getRolePriority(a.role);
+        if (priorityDiff !== 0) return priorityDiff;
+        return a.name.localeCompare(b.name);
+      })
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const orderedSummary = roleSummaryOrder.reduce((acc, role) => {
+    if (roleSummary[role]) {
+      acc.push({ role, count: roleSummary[role] });
+    }
+    return acc;
+  }, []);
+
+  return res.json({
+    units: sortedUnits,
+    roleSummary: orderedSummary,
+    totalUsers: users.length,
+    generatedAt: new Date().toISOString()
+  });
+});
+
+router.get('/subadmins', requireRole(Roles.SUPER_ADMIN), (req, res) => {
+  const subAdmins = listSubAdmins();
+  const cache = new Map();
+  const enriched = subAdmins.map((user) => {
+    const role = normalizeRole(user.role);
+    if (!cache.has(role)) {
+      cache.set(role, getRolePermissions(role));
+    }
+    return {
+      ...user,
+      permissions: cache.get(role)
+    };
+  });
+  return res.json({ subAdmins: enriched });
+});
+
+router.post('/subadmins', requireRole(Roles.SUPER_ADMIN), (req, res) => {
+  const { error, value } = subAdminSchema.validate(req.body, { abortEarly: false, stripUnknown: true });
+  if (error) {
+    return res.status(400).json({ error: 'Invalid sub-admin payload', details: error.details.map((detail) => detail.message) });
+  }
+  const normalizedRole = normalizeRole(value.role);
+  const actorRole = normalizeRole(req.user.role);
+  if (normalizedRole === Roles.SUPER_ADMIN && actorRole !== Roles.GLOBAL_ADMIN) {
+    return res.status(403).json({ error: 'Only the Global Admin can create Super Admins.' });
+  }
+  if (normalizedRole === Roles.ADMIN && ![Roles.GLOBAL_ADMIN, Roles.SUPER_ADMIN].includes(actorRole)) {
+    return res.status(403).json({ error: 'Insufficient privileges to create an Admin account.' });
+  }
+  try {
+    const newUser = createSubAdmin({
+      name: value.name,
+      email: value.email,
+      password: value.password,
+      role: normalizedRole,
+      department: value.department,
+      status: value.status,
+      createdByUserId: req.user.id
+    });
+    recordAuditLog({
+      actorUserId: req.user.id,
+      targetUserId: newUser.id,
+      action: 'subadmin_created',
+      details: {
+        role: newUser.role,
+        department: newUser.department || null
+      }
+    });
+    const permissions = getRolePermissions(newUser.role);
+    return res.status(201).json({ subAdmin: { ...newUser, permissions } });
+  } catch (creationError) {
+    const status = creationError.status || 500;
+    return res.status(status).json({ error: creationError.message || 'Unable to create sub-admin' });
+  }
+});
+
+router.delete('/subadmins/:id', requireRole(Roles.SUPER_ADMIN), (req, res) => {
+  const targetId = String(req.params.id || '').trim();
+  if (!targetId) {
+    return res.status(400).json({ error: 'Sub-admin id is required' });
+  }
+  const actorRole = normalizeRole(req.user.role);
+  const target = getUserById(targetId);
+  if (!target) {
+    return res.status(404).json({ error: 'Sub-admin not found' });
+  }
+  if (target.id === req.user.id) {
+    return res.status(400).json({ error: 'You cannot change your own status.' });
+  }
+  const targetRole = normalizeRole(target.role);
+  if (![Roles.ADMIN, Roles.SUPER_ADMIN].includes(targetRole)) {
+    return res.status(400).json({ error: 'Only admin accounts can be terminated via this endpoint.' });
+  }
+  if (!roleHigherThan(actorRole, targetRole)) {
+    return res.status(403).json({ error: 'You do not have sufficient privileges to remove that account.' });
+  }
+  const previousStatus = target.status;
+  const updated = removeSubAdmin(targetId);
+  recordAuditLog({
+    actorUserId: req.user.id,
+    targetUserId: targetId,
+    action: 'subadmin_status_changed',
+    details: {
+      role: updated.role,
+      previousStatus,
+      newStatus: updated.status
+    }
+  });
+  const permissions = getRolePermissions(updated.role);
+  return res.json({ subAdmin: { ...updated, permissions } });
+});
+
+router.get('/roles', requireRole(Roles.SUPER_ADMIN), (_req, res) => {
+  const roles = listRoles().map((role) => ({
+    ...role,
+    permissions: getRolePermissions(role.id)
+  }));
+  return res.json({ roles });
+});
+
+router.get('/roles/:roleId/permissions', requireRole(Roles.SUPER_ADMIN), (req, res) => {
+  const roleId = normalizeRole(req.params.roleId);
+  if (!listRoles().some((role) => role.id === roleId)) {
+    return res.status(404).json({ error: 'Role not found' });
+  }
+  return res.json({ roleId, permissions: getRolePermissions(roleId) });
+});
+
+router.patch('/roles/:roleId/permissions', requireRole(Roles.SUPER_ADMIN), (req, res) => {
+  const { error, value } = permissionUpdateSchema.validate(req.body, { abortEarly: false, stripUnknown: true });
+  if (error) {
+    return res.status(400).json({ error: 'Invalid permission payload', details: error.details.map((detail) => detail.message) });
+  }
+  const targetRole = normalizeRole(req.params.roleId);
+  const actorRole = normalizeRole(req.user.role);
+  if (targetRole === Roles.GLOBAL_ADMIN) {
+    return res.status(403).json({ error: 'Global Admin permissions cannot be modified.' });
+  }
+  if (!roleHigherThan(actorRole, targetRole)) {
+    return res.status(403).json({ error: 'You cannot modify permissions for an equal or higher role.' });
+  }
+  try {
+    const permissions = setRolePermission({
+      roleId: targetRole,
+      permission: value.permission,
+      allowed: value.allowed,
+      updatedByUserId: req.user.id
+    });
+    return res.json({ roleId: targetRole, permissions });
+  } catch (updateError) {
+    const status = updateError.status || 500;
+    return res.status(status).json({ error: updateError.message || 'Unable to update permission' });
+  }
+});
+
+module.exports = router;

--- a/src/routes/payments.js
+++ b/src/routes/payments.js
@@ -10,12 +10,13 @@ const {
   updatePaymentStatus,
   createReversal
 } = require('../models/payments');
+const { roleAtLeast, Roles } = require('../utils/rbac');
 
 const router = express.Router();
 
 function assertOwnership(req, booking) {
   if (!booking) return false;
-  if (req.user.role === 'admin') return true;
+  if (req.user && roleAtLeast(req.user.role, Roles.ADMIN)) return true;
   return booking.userId === req.user.id;
 }
 

--- a/src/server.js
+++ b/src/server.js
@@ -26,6 +26,7 @@ const {
   releaseSeat: socketReleaseSeat
 } = require('./services/diningSeatLocks');
 const { getUserFromRequest } = require('./utils/jwt');
+const { roleAtLeast, Roles } = require('./utils/rbac');
 
 const server = http.createServer(app);
 function normalizeOrigin(origin) {
@@ -216,7 +217,7 @@ io.on('connection', (socket) => {
   emitUnreadUpdate(user.id);
 
   socket.on('admin:subscribe', (channel) => {
-    if (user.role !== 'admin') {
+    if (!roleAtLeast(user.role, Roles.ADMIN)) {
       return;
     }
     if (channel === 'inquiries') {

--- a/src/utils/jwt.js
+++ b/src/utils/jwt.js
@@ -1,6 +1,7 @@
 const jwt = require('jsonwebtoken');
 const cookie = require('cookie');
 const { DEFAULT_JWT_SECRET } = require('./jwtDefaults');
+const { normalizeRole, Roles } = require('./rbac');
 
 function parseCookies(req) {
   const header = req.headers?.cookie || req.request?.headers?.cookie;
@@ -57,7 +58,7 @@ function formatUserLike(userLike) {
     id,
     email: email || null,
     name: name || null,
-    role: role || 'guest'
+    role: normalizeRole(role || Roles.EMPLOYEE)
   };
 }
 
@@ -103,7 +104,7 @@ function issueSessionToken(res, user) {
     sub: user.id,
     email: user.email,
     name: user.name || null,
-    role: user.role || 'guest',
+    role: normalizeRole(user.role || Roles.EMPLOYEE),
   };
   const token = jwt.sign(payload, signing.key, {
     algorithm: signing.algorithm,

--- a/src/utils/rbac.js
+++ b/src/utils/rbac.js
@@ -1,0 +1,104 @@
+const Roles = Object.freeze({
+  GLOBAL_ADMIN: 'GLOBAL_ADMIN',
+  SUPER_ADMIN: 'SUPER_ADMIN',
+  ADMIN: 'ADMIN',
+  EMPLOYEE: 'EMPLOYEE'
+});
+
+const RolePriority = Object.freeze({
+  [Roles.EMPLOYEE]: 10,
+  [Roles.ADMIN]: 30,
+  [Roles.SUPER_ADMIN]: 40,
+  [Roles.GLOBAL_ADMIN]: 50
+});
+
+const Permissions = Object.freeze({
+  MANAGE_EMPLOYEES: 'manage:employees',
+  RESET_PASSWORDS: 'reset:passwords',
+  APPROVE_TRANSFERS: 'approve:transfers',
+  MANAGE_PERMISSIONS: 'manage:permissions'
+});
+
+const ALL_PERMISSIONS = Object.freeze(Object.values(Permissions));
+
+function normalizeRole(role) {
+  if (!role || typeof role !== 'string') {
+    return Roles.EMPLOYEE;
+  }
+  const upper = role.trim().toUpperCase();
+  if (Roles[upper]) {
+    return Roles[upper];
+  }
+  const match = Object.values(Roles).find((value) => value === upper);
+  return match || Roles.EMPLOYEE;
+}
+
+function getRolePriority(role) {
+  const normalized = normalizeRole(role);
+  return RolePriority[normalized] || 0;
+}
+
+function roleAtLeast(role, minimumRole) {
+  return getRolePriority(role) >= getRolePriority(minimumRole);
+}
+
+function roleHigherThan(role, otherRole) {
+  return getRolePriority(role) > getRolePriority(otherRole);
+}
+
+function isValidPermission(permission) {
+  if (!permission || typeof permission !== 'string') {
+    return false;
+  }
+  return ALL_PERMISSIONS.includes(permission);
+}
+
+function buildUnauthorizedResponse(req, res) {
+  if (req.originalUrl && req.originalUrl.startsWith('/api')) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  if (req.session) {
+    req.session.returnTo = req.originalUrl;
+  }
+  if (typeof req.pushAlert === 'function') {
+    req.pushAlert('warning', 'Please log in to continue your Skyhaven journey.');
+  }
+  return res.redirect('/login');
+}
+
+function buildForbiddenResponse(req, res, message) {
+  if (req.originalUrl && req.originalUrl.startsWith('/api')) {
+    return res.status(403).json({ error: message || 'Forbidden' });
+  }
+  if (typeof req.pushAlert === 'function') {
+    req.pushAlert('danger', message || 'You do not have the required privileges to access that area.');
+  }
+  return res.redirect('/dashboard');
+}
+
+function requireRole(minimumRole, options = {}) {
+  const minRoleNormalized = normalizeRole(minimumRole);
+  const forbiddenMessage = options.forbiddenMessage;
+  return function roleMiddleware(req, res, next) {
+    if (!req.user) {
+      return buildUnauthorizedResponse(req, res);
+    }
+    const userRole = normalizeRole(req.user.role);
+    if (!roleAtLeast(userRole, minRoleNormalized)) {
+      return buildForbiddenResponse(req, res, forbiddenMessage);
+    }
+    return next();
+  };
+}
+
+module.exports = {
+  Roles,
+  Permissions,
+  ALL_PERMISSIONS,
+  normalizeRole,
+  getRolePriority,
+  roleAtLeast,
+  roleHigherThan,
+  isValidPermission,
+  requireRole
+};

--- a/views/admin/index.ejs
+++ b/views/admin/index.ejs
@@ -7,6 +7,145 @@
   <h1>Control deck</h1>
   <p>Monitor inventory, track bookings, and respond to guest signals across <%= hotelName %>.</p>
 
+  <% const roleLabels = { GLOBAL_ADMIN: 'Global Admin', SUPER_ADMIN: 'Super Admin', ADMIN: 'Admin', EMPLOYEE: 'Employee' }; %>
+  <% const roleDescriptions = {
+    GLOBAL_ADMIN: 'Architects the Skyhaven ecosystem and steers every console.',
+    SUPER_ADMIN: 'Oversees regional consoles and mentors Admin teams.',
+    ADMIN: 'Runs day-to-day guest operations and supports on-site teams.',
+    EMPLOYEE: 'Provides world-class service across the hotel.'
+  }; %>
+  <% const actorRoleLabel = roleLabels[adminAccess.actorRole] || 'Admin'; %>
+  <% const allowedRoleLabels = (adminAccess.allowedSubAdminRoles || []).map(function(role) { return roleLabels[role]; }); %>
+  <% let delegationIntro; %>
+  <% if (adminAccess.actorRole === 'GLOBAL_ADMIN') { %>
+    <% delegationIntro = 'You can elevate trusted leaders into Super Admin or Admin roles and fine-tune their privileges.'; %>
+  <% } else if (adminAccess.actorRole === 'SUPER_ADMIN') { %>
+    <% delegationIntro = 'You can create Admin accounts and tailor their operational privileges. Reach out to the Global Admin for Super Admin promotions.'; %>
+  <% } else { %>
+    <% delegationIntro = 'You can orchestrate bookings, amenities, and inquiries. Coordinate with a Super Admin if your team needs additional admin accounts.'; %>
+  <% } %>
+
+  <section class="admin-panel admin-access-panel">
+    <div class="admin-access-header">
+      <div>
+        <h2>Administrative hierarchy</h2>
+        <p class="admin-access-subtitle">Delegate control of Skyhaven's systems with precision.</p>
+      </div>
+      <span class="role-badge role-badge--<%= String(adminAccess.actorRole || '').toLowerCase() %>">
+        <span class="role-badge__label"><%= actorRoleLabel %></span>
+      </span>
+    </div>
+    <p class="admin-access-copy"><%= delegationIntro %></p>
+    <% if (allowedRoleLabels.length) { %>
+      <p class="admin-access-hint">
+        Delegation options: <strong><%= allowedRoleLabels.join(', ') %></strong>
+      </p>
+      <div
+        class="subadmin-wizard"
+        data-subadmin-wizard
+        data-config='<%- JSON.stringify({ allowedSubAdminRoles: adminAccess.allowedSubAdminRoles, actorRole: adminAccess.actorRole }) %>'
+      >
+        <div class="subadmin-wizard__stage" data-stage="select">
+          <h3>Choose an access tier</h3>
+          <p class="muted">Select the level of control you want to grant.</p>
+          <div class="subadmin-wizard__roles">
+            <% adminAccess.allowedSubAdminRoles.forEach(function(role) { %>
+              <button type="button" class="subadmin-role" data-role-option data-role="<%= role %>">
+                <span class="subadmin-role__label"><%= roleLabels[role] %></span>
+                <span class="subadmin-role__detail"><%= roleDescriptions[role] || 'Provides operational coverage across the hotel.' %></span>
+              </button>
+            <% }) %>
+          </div>
+          <div class="subadmin-wizard__actions">
+            <button type="button" class="pill-link primary" data-action="advance" disabled>Continue</button>
+          </div>
+        </div>
+        <div class="subadmin-wizard__stage" data-stage="details" hidden>
+          <h3>Set up a new <span data-selected-role-label>Admin</span></h3>
+          <form data-subadmin-form novalidate>
+            <input type="hidden" name="role" data-role-input />
+            <div class="subadmin-form-grid">
+              <label class="subadmin-field">
+                <span class="subadmin-field__label">Full name</span>
+                <input type="text" name="name" required autocomplete="name" placeholder="Nova Patel" />
+              </label>
+              <label class="subadmin-field">
+                <span class="subadmin-field__label">Email</span>
+                <input type="email" name="email" required autocomplete="email" placeholder="nova@skyhaven.test" />
+              </label>
+              <label class="subadmin-field">
+                <span class="subadmin-field__label">Temporary password</span>
+                <input type="password" name="password" required autocomplete="new-password" minlength="8" placeholder="Min. 8 characters" />
+                <small class="subadmin-field__hint">Share securely with the new admin and encourage a reset on first login.</small>
+              </label>
+              <label class="subadmin-field">
+                <span class="subadmin-field__label">Department (optional)</span>
+                <input type="text" name="department" autocomplete="organization" placeholder="Front Desk" />
+              </label>
+            </div>
+            <p class="subadmin-feedback" data-subadmin-feedback aria-live="polite"></p>
+            <div class="subadmin-wizard__actions">
+              <button type="button" class="pill-link secondary" data-action="back">Back</button>
+              <button type="submit" class="pill-link primary" data-action="submit">
+                Create <span data-selected-role-label>Admin</span>
+              </button>
+            </div>
+          </form>
+        </div>
+        <div class="subadmin-wizard__stage" data-stage="result" hidden>
+          <div class="subadmin-success">
+            <h3>Delegation complete</h3>
+            <p>
+              <strong data-result-name></strong>
+              now has <span data-result-role></span> privileges.
+            </p>
+          </div>
+          <div class="subadmin-wizard__actions">
+            <button type="button" class="pill-link secondary" data-action="finish-wizard">Close</button>
+            <button type="button" class="pill-link primary" data-action="create-another">Create another</button>
+          </div>
+        </div>
+      </div>
+    <% } else { %>
+      <div class="admin-access-note">
+        <p class="muted">
+          Delegating new admin accounts requires Super Admin privileges. Coordinate with your Super Admin team if you need additional coverage.
+        </p>
+      </div>
+    <% } %>
+  </section>
+
+  <% if (adminAccess.allowedSubAdminRoles && adminAccess.allowedSubAdminRoles.length) { %>
+    <section class="admin-panel subadmin-roster-panel" data-subadmin-roster data-empty-text="No delegated administrators yet.">
+      <div class="subadmin-roster__header">
+        <div>
+          <h2>Delegated administrators</h2>
+          <p class="muted">Keep track of the teammates you've elevated.</p>
+        </div>
+        <button type="button" class="pill-link secondary" data-roster-refresh>Refresh</button>
+      </div>
+      <p class="subadmin-roster__feedback" data-roster-feedback aria-live="polite"></p>
+      <div class="panel-scroll">
+        <table class="admin-table subadmin-table">
+          <thead>
+            <tr>
+              <th>Administrator</th>
+              <th>Role</th>
+              <th>Department</th>
+              <th>Status</th>
+              <th>Privileges</th>
+            </tr>
+          </thead>
+          <tbody data-roster-body>
+            <tr data-roster-loading>
+              <td colspan="5">Loading delegated administrators…</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  <% } %>
+
   <div class="admin-metrics">
     <% metrics.forEach(function(metric) { %>
       <article class="metric-card">

--- a/views/partials/nav.ejs
+++ b/views/partials/nav.ejs
@@ -40,7 +40,7 @@
           </a>
           <a href="/dashboard" class="nav-link">Dashboard</a>
           <a href="/dining/account/reservations" class="nav-link">Dining account</a>
-          <% if (currentUser.role === 'admin') { %>
+          <% if (['ADMIN', 'SUPER_ADMIN', 'GLOBAL_ADMIN'].includes(String(currentUser.role || '').toUpperCase())) { %>
             <a href="/admin" class="nav-link">Admin</a>
           <% } %>
         <% } %>


### PR DESCRIPTION
## Summary
- expose the admin console link to every admin-grade role and provide role metadata to the admin view
- redesign /admin with a delegation wizard and roster section that respect global vs super admin capabilities
- add styling and client logic to drive the sub-admin workflow while keeping existing inquiry updates intact

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68edc4db9e5c8323b2a09fbecaba2e70