### PR TITLE
Improve admin employee status controls

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -3901,3 +3901,385 @@ html[data-animations='enabled'] [data-animate].is-visible {
     width: 100%;
   }
 }
+
+.admin-panel--employees {
+  margin-bottom: var(--space-5);
+  padding: var(--space-5);
+  background: var(--color-surface-alt);
+  border-radius: 1rem;
+  box-shadow: 0 0 24px rgba(94, 252, 255, 0.08);
+}
+
+.employees-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.employees-header h2 {
+  margin-bottom: var(--space-2);
+}
+
+.employees-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.employees-toolbar {
+  margin-top: var(--space-4);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  align-items: center;
+  justify-content: space-between;
+}
+
+.toolbar-search {
+  flex: 1 1 260px;
+}
+
+.toolbar-search input[type='search'] {
+  width: 100%;
+  padding: var(--space-3);
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 208, 0.3);
+  background: rgba(9, 13, 28, 0.65);
+  color: var(--color-text);
+}
+
+.toolbar-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.toolbar-filters select {
+  min-width: 160px;
+  padding: var(--space-2) var(--space-3);
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 208, 0.25);
+  background: rgba(9, 13, 28, 0.8);
+  color: var(--color-text);
+}
+
+.employees-bulk {
+  margin-top: var(--space-3);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+.employees-bulk select {
+  padding: var(--space-2) var(--space-3);
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 208, 0.25);
+  background: rgba(9, 13, 28, 0.8);
+  color: var(--color-text);
+}
+
+.employee-table-wrapper {
+  margin-top: var(--space-4);
+  overflow-x: auto;
+}
+
+.employee-table input,
+.employee-table select {
+  width: 100%;
+  padding: var(--space-2);
+  border-radius: 0.5rem;
+  border: 1px solid rgba(148, 163, 208, 0.25);
+  background: rgba(9, 13, 28, 0.7);
+  color: var(--color-text);
+}
+
+.employee-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.employee-actions .pill-link {
+  padding: 0.35rem 0.8rem;
+  font-size: 0.75rem;
+}
+
+.employee-pagination {
+  margin-top: var(--space-4);
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: var(--space-3);
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.employee-detail {
+  margin-top: var(--space-4);
+  padding: var(--space-4);
+  border-radius: 1rem;
+  background: rgba(7, 11, 24, 0.85);
+  border: 1px solid rgba(148, 163, 208, 0.2);
+}
+
+.detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.detail-grid dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+  margin-bottom: 0.25rem;
+}
+
+.detail-grid dd {
+  margin: 0;
+}
+
+.employee-modal {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 40;
+}
+
+.employee-modal.is-visible {
+  display: flex;
+}
+
+.employee-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(5, 1, 20, 0.75);
+  backdrop-filter: blur(4px);
+}
+
+.employee-modal__content {
+  position: relative;
+  background: rgba(11, 15, 31, 0.95);
+  border: 1px solid rgba(148, 163, 208, 0.3);
+  box-shadow: 0 32px 60px rgba(5, 1, 20, 0.6);
+  border-radius: 1.25rem;
+  padding: var(--space-5);
+  width: min(720px, 92vw);
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.employee-modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+}
+
+.employee-form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--space-3);
+}
+
+.employee-form-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.employee-form-grid input,
+.employee-form-grid select,
+.employee-form-grid textarea {
+  width: 100%;
+  padding: var(--space-3);
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 208, 0.3);
+  background: rgba(9, 13, 28, 0.8);
+  color: var(--color-text);
+}
+
+.employee-form-grid textarea {
+  resize: vertical;
+  min-height: 110px;
+}
+
+.employee-modal__footer {
+  margin-top: var(--space-4);
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+}
+
+.employee-toast,
+.request-toast {
+  position: fixed;
+  right: 2rem;
+  bottom: 2.5rem;
+  padding: var(--space-3) var(--space-4);
+  border-radius: 999px;
+  background: rgba(11, 15, 31, 0.92);
+  border: 1px solid rgba(148, 163, 208, 0.3);
+  color: var(--color-text);
+  box-shadow: 0 12px 30px rgba(5, 1, 20, 0.45);
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 45;
+}
+
+.employee-toast.is-visible,
+.request-toast.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.employee-toast.is-success,
+.request-toast.is-success {
+  border-color: rgba(54, 251, 192, 0.6);
+  box-shadow: 0 12px 30px rgba(54, 251, 192, 0.15);
+}
+
+.employee-toast.is-error,
+.request-toast.is-error {
+  border-color: rgba(255, 107, 129, 0.6);
+  box-shadow: 0 12px 30px rgba(255, 107, 129, 0.18);
+}
+
+.admin-requests {
+  padding: var(--space-5);
+  background: var(--color-surface-alt);
+  border-radius: 1.25rem;
+  box-shadow: 0 0 24px rgba(140, 123, 255, 0.12);
+}
+
+.requests-header h1 {
+  margin-bottom: var(--space-2);
+}
+
+.requests-toolbar {
+  margin-top: var(--space-4);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  align-items: center;
+}
+
+.requests-toolbar input[type='search'] {
+  flex: 1 1 260px;
+  padding: var(--space-3);
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 208, 0.25);
+  background: rgba(9, 13, 28, 0.65);
+  color: var(--color-text);
+}
+
+.requests-filters {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.requests-filters select {
+  min-width: 150px;
+  padding: var(--space-2) var(--space-3);
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 208, 0.25);
+  background: rgba(9, 13, 28, 0.8);
+  color: var(--color-text);
+}
+
+.requests-table-wrapper {
+  margin-top: var(--space-4);
+  overflow-x: auto;
+}
+
+.request-detail {
+  margin-top: var(--space-4);
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 208, 0.25);
+  background: rgba(7, 11, 24, 0.88);
+  padding: var(--space-4);
+}
+
+.request-detail .detail-body {
+  margin-top: var(--space-3);
+}
+
+.payload-list {
+  margin: 0;
+  padding-left: var(--space-4);
+}
+
+.payload-list li {
+  margin-bottom: 0.35rem;
+  font-size: 0.9rem;
+}
+
+.request-decision {
+  margin-top: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.request-decision textarea {
+  width: 100%;
+  padding: var(--space-3);
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 208, 0.25);
+  background: rgba(9, 13, 28, 0.8);
+  color: var(--color-text);
+  resize: vertical;
+  min-height: 110px;
+}
+
+.decision-actions {
+  display: flex;
+  gap: var(--space-2);
+  justify-content: flex-end;
+}
+
+.requests-pagination {
+  margin-top: var(--space-4);
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: var(--space-3);
+  color: var(--color-muted);
+  font-size: 0.85rem;
+}
+
+@media (max-width: 960px) {
+  .employees-header,
+  .employees-toolbar,
+  .employees-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .requests-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .requests-filters,
+  .employees-bulk {
+    width: 100%;
+  }
+}

--- a/public/js/admin-employees.js
+++ b/public/js/admin-employees.js
@@ -1,0 +1,720 @@
+(() => {
+  const tableBody = document.querySelector('[data-employee-rows]');
+  if (!tableBody) {
+    return;
+  }
+
+  const searchInput = document.querySelector('[data-employee-search]');
+  const filterDepartment = document.querySelector('[data-employee-filter="department"]');
+  const filterStatus = document.querySelector('[data-employee-filter="status"]');
+  const filterEmployment = document.querySelector('[data-employee-filter="employmentType"]');
+  const paginationEl = document.querySelector('[data-employee-pagination]');
+  const bulkForm = document.querySelector('[data-employee-bulk]');
+  const bulkDepartment = bulkForm?.querySelector('[data-bulk-department]');
+  const bulkStatus = bulkForm?.querySelector('[data-bulk-status]');
+  const bulkApply = bulkForm?.querySelector('[data-bulk-apply]');
+  const detailPanel = document.querySelector('[data-employee-detail]');
+  const toastEl = document.querySelector('[data-employee-toast]');
+  const importButton = document.querySelector('[data-import-leadership]');
+  const newButton = document.querySelector('[data-open-create]');
+  const modal = document.querySelector('[data-employee-modal]');
+  const modalTitle = modal?.querySelector('[data-modal-title]');
+  const modalForm = modal?.querySelector('[data-employee-form]');
+  const submitLabel = modal?.querySelector('[data-submit-label]');
+
+  const csrfToken = window.__CSRF_TOKEN__ || document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+  const state = {
+    employees: [],
+    pagination: { page: 1, pageSize: 20, totalPages: 0, total: 0 },
+    filters: { departments: [], statuses: [], employmentTypes: [] },
+    query: { search: '', department: '', status: '', employmentType: '' },
+    selected: new Set(),
+    loading: false,
+    detailId: null
+  };
+
+  const statusFallback = ['active', 'on-leave', 'suspended', 'terminated'];
+
+  function uniqueOptions(values = []) {
+    const seen = new Map();
+    values.forEach((raw) => {
+      if (raw == null) return;
+      const value = String(raw).trim();
+      if (!value) return;
+      const key = value.toLowerCase();
+      if (!seen.has(key)) {
+        seen.set(key, value);
+      }
+    });
+    return Array.from(seen.values());
+  }
+
+  function getStatusOptions() {
+    const combined = uniqueOptions([...(state.filters.statuses || []), ...statusFallback]);
+    if (combined.length === 0) {
+      return statusFallback.slice();
+    }
+    return combined;
+  }
+
+  function setSelectOptions(select, values, options = {}) {
+    if (!select) return;
+    const {
+      placeholder,
+      placeholderValue = '',
+      selectedValue,
+      includeExistingValue = true
+    } = options;
+    const previousValue =
+      typeof selectedValue === 'string' ? selectedValue : typeof select.value === 'string' ? select.value : '';
+    select.innerHTML = '';
+    if (typeof placeholder === 'string') {
+      const option = document.createElement('option');
+      option.value = placeholderValue;
+      option.textContent = placeholder;
+      if (!previousValue) {
+        option.selected = true;
+      }
+      select.appendChild(option);
+    }
+    let hasMatch = false;
+    values.forEach((value) => {
+      const option = document.createElement('option');
+      option.value = value;
+      option.textContent = value;
+      if (previousValue && value.toLowerCase() === previousValue.toLowerCase()) {
+        option.selected = true;
+        hasMatch = true;
+      }
+      select.appendChild(option);
+    });
+    if (previousValue && !hasMatch && includeExistingValue) {
+      const option = document.createElement('option');
+      option.value = previousValue;
+      option.textContent = previousValue;
+      option.selected = true;
+      select.appendChild(option);
+    }
+  }
+
+  function showToast(message, tone = 'info') {
+    if (!toastEl) return;
+    toastEl.textContent = message;
+    toastEl.classList.remove('is-info', 'is-error', 'is-success');
+    toastEl.classList.add('is-visible');
+    if (tone === 'error') {
+      toastEl.classList.add('is-error');
+    } else if (tone === 'success') {
+      toastEl.classList.add('is-success');
+    } else {
+      toastEl.classList.add('is-info');
+    }
+    window.clearTimeout(toastEl.dataset.timeoutId);
+    const timeoutId = window.setTimeout(() => {
+      toastEl.classList.remove('is-visible');
+    }, 5000);
+    toastEl.dataset.timeoutId = String(timeoutId);
+  }
+
+  function clearToast() {
+    if (!toastEl) return;
+    toastEl.classList.remove('is-visible', 'is-info', 'is-error', 'is-success');
+    toastEl.textContent = '';
+  }
+
+  function createRequestOptions(method = 'GET', body) {
+    const headers = { 'CSRF-Token': csrfToken };
+    if (body) {
+      headers['Content-Type'] = 'application/json';
+    }
+    const options = { method, headers };
+    if (body) {
+      options.body = JSON.stringify(body);
+    }
+    return options;
+  }
+
+  async function http(url, options) {
+    const response = await fetch(url, options);
+    if (!response.ok) {
+      const text = await response.text();
+      let message = response.statusText || 'Request failed';
+      try {
+        const payload = JSON.parse(text);
+        message = payload.error || payload.message || message;
+      } catch (parseError) {
+        // Ignore parse errors and use the default message.
+      }
+      throw new Error(message);
+    }
+    if (response.status === 204) {
+      return null;
+    }
+    const contentType = response.headers.get('content-type') || '';
+    if (contentType.includes('application/json')) {
+      return response.json();
+    }
+    return response.text();
+  }
+
+  function setLoading(isLoading) {
+    state.loading = isLoading;
+    if (isLoading && tableBody) {
+      tableBody.innerHTML = '';
+      const row = document.createElement('tr');
+      const cell = document.createElement('td');
+      cell.colSpan = 8;
+      cell.textContent = 'Loading employee roster…';
+      row.appendChild(cell);
+      tableBody.appendChild(row);
+    }
+  }
+
+  function updateSelectedCheckbox(id, checked) {
+    if (checked) {
+      state.selected.add(id);
+    } else {
+      state.selected.delete(id);
+    }
+    updateBulkButtonState();
+  }
+
+  function markRowDirty(row) {
+    row.dataset.dirty = 'true';
+    const saveButton = row.querySelector('[data-action="save"]');
+    if (saveButton) {
+      saveButton.disabled = false;
+    }
+  }
+
+  function renderEmployees() {
+    if (!tableBody) return;
+    tableBody.innerHTML = '';
+    if (!state.employees.length) {
+      const emptyRow = document.createElement('tr');
+      const emptyCell = document.createElement('td');
+      emptyCell.colSpan = 8;
+      emptyCell.textContent = state.query.search || state.query.department || state.query.status || state.query.employmentType
+        ? 'No employees match the filters.'
+        : 'No employees recorded yet.';
+      emptyRow.appendChild(emptyCell);
+      tableBody.appendChild(emptyRow);
+      return;
+    }
+
+    state.employees.forEach((employee) => {
+      const row = document.createElement('tr');
+      row.dataset.employeeId = employee.id;
+
+      const selectCell = document.createElement('td');
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.checked = state.selected.has(employee.id);
+      checkbox.addEventListener('change', (event) => {
+        updateSelectedCheckbox(employee.id, event.target.checked);
+      });
+      selectCell.appendChild(checkbox);
+      row.appendChild(selectCell);
+
+      const nameCell = document.createElement('td');
+      const stack = document.createElement('div');
+      stack.className = 'stacked';
+      const nameStrong = document.createElement('strong');
+      nameStrong.textContent = employee.name;
+      const emailSpan = document.createElement('span');
+      emailSpan.className = 'muted';
+      emailSpan.textContent = employee.email;
+      stack.appendChild(nameStrong);
+      stack.appendChild(emailSpan);
+      if (employee.phone) {
+        const phoneSpan = document.createElement('span');
+        phoneSpan.className = 'muted';
+        phoneSpan.textContent = employee.phone;
+        stack.appendChild(phoneSpan);
+      }
+      nameCell.appendChild(stack);
+      row.appendChild(nameCell);
+
+      const titleCell = document.createElement('td');
+      const titleInput = document.createElement('input');
+      titleInput.type = 'text';
+      titleInput.value = employee.title || '';
+      titleInput.dataset.inlineField = 'title';
+      titleInput.addEventListener('input', () => markRowDirty(row));
+      titleCell.appendChild(titleInput);
+      row.appendChild(titleCell);
+
+      const departmentCell = document.createElement('td');
+      const departmentInput = document.createElement('input');
+      departmentInput.type = 'text';
+      departmentInput.value = employee.department || '';
+      departmentInput.dataset.inlineField = 'department';
+      departmentInput.addEventListener('input', () => markRowDirty(row));
+      departmentCell.appendChild(departmentInput);
+      row.appendChild(departmentCell);
+
+      const employmentCell = document.createElement('td');
+      const employmentSpan = document.createElement('span');
+      employmentSpan.textContent = employee.employmentType || '—';
+      employmentCell.appendChild(employmentSpan);
+      row.appendChild(employmentCell);
+
+      const statusCell = document.createElement('td');
+      const statusSelect = document.createElement('select');
+      statusSelect.dataset.inlineField = 'status';
+      const statuses = getStatusOptions();
+      statuses.forEach((status) => {
+        const option = document.createElement('option');
+        option.value = status;
+        option.textContent = status;
+        if ((employee.status || '').toLowerCase() === status.toLowerCase()) {
+          option.selected = true;
+        }
+        statusSelect.appendChild(option);
+      });
+      statusSelect.addEventListener('change', () => markRowDirty(row));
+      statusCell.appendChild(statusSelect);
+      row.appendChild(statusCell);
+
+      const startCell = document.createElement('td');
+      startCell.textContent = employee.startDate || '—';
+      row.appendChild(startCell);
+
+      const actionsCell = document.createElement('td');
+      actionsCell.className = 'employee-actions';
+      const actions = document.createElement('div');
+      actions.className = 'actions-stack';
+
+      const saveButton = document.createElement('button');
+      saveButton.type = 'button';
+      saveButton.className = 'pill-link primary';
+      saveButton.textContent = 'Save';
+      saveButton.dataset.action = 'save';
+      saveButton.disabled = true;
+      actions.appendChild(saveButton);
+
+      const viewButton = document.createElement('button');
+      viewButton.type = 'button';
+      viewButton.className = 'pill-link';
+      viewButton.textContent = 'View';
+      viewButton.dataset.action = 'view';
+      actions.appendChild(viewButton);
+
+      const editButton = document.createElement('button');
+      editButton.type = 'button';
+      editButton.className = 'pill-link secondary';
+      editButton.textContent = 'Edit';
+      editButton.dataset.action = 'edit';
+      actions.appendChild(editButton);
+
+      const resetButton = document.createElement('button');
+      resetButton.type = 'button';
+      resetButton.className = 'pill-link secondary';
+      resetButton.textContent = 'Reset password';
+      resetButton.dataset.action = 'reset';
+      actions.appendChild(resetButton);
+
+      const disableButton = document.createElement('button');
+      disableButton.type = 'button';
+      disableButton.className = 'pill-link secondary';
+      disableButton.textContent = 'Disable';
+      disableButton.dataset.action = 'disable';
+      actions.appendChild(disableButton);
+
+      const deleteButton = document.createElement('button');
+      deleteButton.type = 'button';
+      deleteButton.className = 'pill-link danger';
+      deleteButton.textContent = 'Delete';
+      deleteButton.dataset.action = 'delete';
+      actions.appendChild(deleteButton);
+
+      actions.addEventListener('click', (event) => {
+        const button = event.target.closest('button[data-action]');
+        if (!button) return;
+        handleRowAction(button.dataset.action, employee, row);
+      });
+
+      actionsCell.appendChild(actions);
+      row.appendChild(actionsCell);
+
+      tableBody.appendChild(row);
+    });
+  }
+
+  function renderFilters() {
+    const departments = uniqueOptions(state.filters.departments || []);
+    setSelectOptions(filterDepartment, departments, {
+      placeholder: 'All departments',
+      placeholderValue: '',
+      selectedValue: state.query.department
+    });
+    setSelectOptions(bulkDepartment, departments, {
+      placeholder: 'Set department…',
+      placeholderValue: '',
+      selectedValue: bulkDepartment?.value || '',
+      includeExistingValue: true
+    });
+
+    const employmentTypes = uniqueOptions(state.filters.employmentTypes || []);
+    setSelectOptions(filterEmployment, employmentTypes, {
+      placeholder: 'All employment types',
+      placeholderValue: '',
+      selectedValue: state.query.employmentType
+    });
+
+    const statuses = getStatusOptions();
+    setSelectOptions(filterStatus, statuses, {
+      placeholder: 'All statuses',
+      placeholderValue: '',
+      selectedValue: state.query.status
+    });
+    setSelectOptions(bulkStatus, statuses, {
+      placeholder: 'Set status…',
+      placeholderValue: '',
+      selectedValue: bulkStatus?.value || '',
+      includeExistingValue: true
+    });
+
+    if (modalForm) {
+      const modalStatus = modalForm.querySelector('[data-field="status"]');
+      setSelectOptions(modalStatus, statuses, {
+        selectedValue: modalStatus?.value || 'active',
+        includeExistingValue: true
+      });
+    }
+  }
+
+  function updatePaginationControls() {
+    if (!paginationEl) return;
+    const prev = paginationEl.querySelector('[data-page="prev"]');
+    const next = paginationEl.querySelector('[data-page="next"]');
+    const status = paginationEl.querySelector('[data-page-status]');
+    if (prev) {
+      prev.disabled = state.pagination.page <= 1;
+    }
+    if (next) {
+      next.disabled = state.pagination.totalPages === 0 || state.pagination.page >= state.pagination.totalPages;
+    }
+    if (status) {
+      status.textContent = `Page ${state.pagination.totalPages === 0 ? 0 : state.pagination.page} of ${state.pagination.totalPages}`;
+    }
+  }
+
+  function updateBulkButtonState() {
+    if (!bulkApply) return;
+    const hasSelection = state.selected.size > 0;
+    const hasUpdates = Boolean((bulkDepartment && bulkDepartment.value) || (bulkStatus && bulkStatus.value));
+    bulkApply.disabled = !(hasSelection && hasUpdates);
+  }
+
+  async function loadEmployees(page = 1) {
+    setLoading(true);
+    clearToast();
+    try {
+      const params = new URLSearchParams();
+      params.set('page', page);
+      if (state.query.search) params.set('search', state.query.search);
+      if (state.query.department) params.set('department', state.query.department);
+      if (state.query.status) params.set('status', state.query.status);
+      if (state.query.employmentType) params.set('employmentType', state.query.employmentType);
+      const data = await http(`/api/admin/employees?${params.toString()}`);
+      state.employees = Array.isArray(data.employees) ? data.employees : [];
+      state.pagination = data.pagination || { page: page, pageSize: 20, totalPages: 0, total: 0 };
+      state.filters = data.filters || state.filters;
+      state.pagination.page = data.pagination?.page || page;
+      const visibleIds = new Set(state.employees.map((employee) => employee.id));
+      Array.from(state.selected).forEach((id) => {
+        if (!visibleIds.has(id)) {
+          state.selected.delete(id);
+        }
+      });
+      renderEmployees();
+      renderFilters();
+      updatePaginationControls();
+      updateBulkButtonState();
+      if (state.detailId) {
+        const employee = state.employees.find((item) => item.id === state.detailId);
+        if (employee) {
+          populateDetail(employee);
+        }
+      }
+    } catch (error) {
+      showToast(error.message || 'Unable to load employees', 'error');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function populateDetail(employee) {
+    if (!detailPanel) return;
+    state.detailId = employee.id;
+    detailPanel.querySelector('[data-detail-name]').textContent = employee.name;
+    detailPanel.querySelector('[data-detail-email]').textContent = employee.email || '';
+    detailPanel.querySelector('[data-detail-department]').textContent = employee.department || '—';
+    detailPanel.querySelector('[data-detail-title]').textContent = employee.title || '—';
+    detailPanel.querySelector('[data-detail-employment]').textContent = employee.employmentType || '—';
+    detailPanel.querySelector('[data-detail-status]').textContent = employee.status || '—';
+    detailPanel.querySelector('[data-detail-start]').textContent = employee.startDate || '—';
+    detailPanel.querySelector('[data-detail-emergency]').textContent = employee.emergencyContact || '—';
+    detailPanel.querySelector('[data-detail-notes]').textContent = employee.notes || 'No notes captured.';
+    detailPanel.hidden = false;
+  }
+
+  function closeDetail() {
+    if (!detailPanel) return;
+    detailPanel.hidden = true;
+    state.detailId = null;
+  }
+
+  function openModal(employee) {
+    if (!modal || !modalForm) return;
+    modal.hidden = false;
+    modal.classList.add('is-visible');
+    if (employee) {
+      modalTitle.textContent = 'Edit employee';
+      submitLabel.textContent = 'Save changes';
+      modalForm.querySelector('[data-field="id"]').value = employee.id;
+      modalForm.querySelector('[data-field="name"]').value = employee.name || '';
+      modalForm.querySelector('[data-field="email"]').value = employee.email || '';
+      modalForm.querySelector('[data-field="phone"]').value = employee.phone || '';
+      modalForm.querySelector('[data-field="department"]').value = employee.department || '';
+      modalForm.querySelector('[data-field="title"]').value = employee.title || '';
+      modalForm.querySelector('[data-field="employmentType"]').value = employee.employmentType || 'Full-Time';
+      modalForm.querySelector('[data-field="startDate"]').value = employee.startDate || '';
+      const statusField = modalForm.querySelector('[data-field="status"]');
+      setSelectOptions(statusField, getStatusOptions(), {
+        selectedValue: employee.status || 'active',
+        includeExistingValue: true
+      });
+      modalForm.querySelector('[data-field="emergencyContact"]').value = employee.emergencyContact || '';
+      modalForm.querySelector('[data-field="notes"]').value = employee.notes || '';
+    } else {
+      modalTitle.textContent = 'New employee';
+      submitLabel.textContent = 'Create employee';
+      modalForm.querySelector('[data-field="id"]').value = '';
+      modalForm.querySelector('[data-field="name"]').value = '';
+      modalForm.querySelector('[data-field="email"]').value = '';
+      modalForm.querySelector('[data-field="phone"]').value = '';
+      modalForm.querySelector('[data-field="department"]').value = '';
+      modalForm.querySelector('[data-field="title"]').value = '';
+      modalForm.querySelector('[data-field="employmentType"]').value = 'Full-Time';
+      modalForm.querySelector('[data-field="startDate"]').value = '';
+      const statusField = modalForm.querySelector('[data-field="status"]');
+      setSelectOptions(statusField, getStatusOptions(), {
+        selectedValue: 'active',
+        includeExistingValue: true
+      });
+      modalForm.querySelector('[data-field="emergencyContact"]').value = '';
+      modalForm.querySelector('[data-field="notes"]').value = '';
+    }
+  }
+
+  function closeModal() {
+    if (!modal) return;
+    modal.classList.remove('is-visible');
+    modal.hidden = true;
+  }
+
+  async function handleRowAction(action, employee, row) {
+    try {
+      if (action === 'save') {
+        const title = row.querySelector('[data-inline-field="title"]').value;
+        const department = row.querySelector('[data-inline-field="department"]').value;
+        const status = row.querySelector('[data-inline-field="status"]').value;
+        await http(`/api/admin/employees/${employee.id}`, createRequestOptions('PATCH', {
+          title,
+          department,
+          status
+        }));
+        showToast(`Updated ${employee.name}.`, 'success');
+        await loadEmployees(state.pagination.page);
+      } else if (action === 'view') {
+        populateDetail(employee);
+      } else if (action === 'edit') {
+        openModal(employee);
+      } else if (action === 'reset') {
+        const data = await http(`/api/admin/employees/${employee.id}/reset-password`, createRequestOptions('POST'));
+        showToast(`Temporary password for ${employee.name}: ${data.temporaryPassword}`, 'success');
+      } else if (action === 'disable') {
+        await http(`/api/admin/employees/${employee.id}`, createRequestOptions('PATCH', { status: 'suspended' }));
+        showToast(`${employee.name} has been disabled.`, 'success');
+        await loadEmployees(state.pagination.page);
+      } else if (action === 'delete') {
+        const confirmed = window.confirm(`Delete ${employee.name}? This cannot be undone.`);
+        if (!confirmed) return;
+        await http(`/api/admin/employees/${employee.id}`, createRequestOptions('DELETE'));
+        state.selected.delete(employee.id);
+        showToast(`${employee.name} removed from roster.`, 'success');
+        await loadEmployees(Math.max(1, state.pagination.page));
+      }
+    } catch (error) {
+      showToast(error.message || 'Unable to complete action', 'error');
+    }
+  }
+
+  let searchTimeout;
+  if (searchInput) {
+    searchInput.addEventListener('input', (event) => {
+      window.clearTimeout(searchTimeout);
+      const value = event.target.value.trim();
+      searchTimeout = window.setTimeout(() => {
+        state.query.search = value;
+        state.pagination.page = 1;
+        loadEmployees(1);
+      }, 250);
+    });
+  }
+
+  if (filterDepartment) {
+    filterDepartment.addEventListener('change', (event) => {
+      state.query.department = event.target.value;
+      state.pagination.page = 1;
+      loadEmployees(1);
+    });
+  }
+  if (filterStatus) {
+    filterStatus.addEventListener('change', (event) => {
+      state.query.status = event.target.value;
+      state.pagination.page = 1;
+      loadEmployees(1);
+    });
+  }
+  if (filterEmployment) {
+    filterEmployment.addEventListener('change', (event) => {
+      state.query.employmentType = event.target.value;
+      state.pagination.page = 1;
+      loadEmployees(1);
+    });
+  }
+
+  if (paginationEl) {
+    paginationEl.addEventListener('click', (event) => {
+      const button = event.target.closest('button[data-page]');
+      if (!button) return;
+      const direction = button.dataset.page;
+      if (direction === 'prev' && state.pagination.page > 1) {
+        loadEmployees(state.pagination.page - 1);
+      } else if (direction === 'next' && state.pagination.page < state.pagination.totalPages) {
+        loadEmployees(state.pagination.page + 1);
+      }
+    });
+  }
+
+  if (bulkForm) {
+    bulkForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      if (state.selected.size === 0) return;
+      const payload = { ids: Array.from(state.selected) };
+      if (bulkDepartment && bulkDepartment.value) {
+        payload.department = bulkDepartment.value;
+      }
+      if (bulkStatus && bulkStatus.value) {
+        payload.status = bulkStatus.value;
+      }
+      try {
+        await http('/api/admin/employees/bulk', createRequestOptions('POST', payload));
+        showToast('Bulk update applied.', 'success');
+        state.selected.clear();
+        if (bulkDepartment) bulkDepartment.value = '';
+        if (bulkStatus) bulkStatus.value = '';
+        updateBulkButtonState();
+        await loadEmployees(state.pagination.page);
+      } catch (error) {
+        showToast(error.message || 'Bulk update failed', 'error');
+      }
+    });
+    bulkDepartment?.addEventListener('change', updateBulkButtonState);
+    bulkStatus?.addEventListener('change', updateBulkButtonState);
+  }
+
+  if (detailPanel) {
+    detailPanel.querySelector('[data-close-detail]')?.addEventListener('click', () => {
+      closeDetail();
+    });
+  }
+
+  if (modal) {
+    modal.addEventListener('click', (event) => {
+      if (event.target.matches('[data-close-modal]') || event.target.classList.contains('employee-modal__backdrop')) {
+        closeModal();
+      }
+    });
+  }
+
+  if (modalForm) {
+    modalForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const formData = new FormData(modalForm);
+      const payload = Object.fromEntries(formData.entries());
+      const id = payload.id;
+      if (!payload.name || !payload.email) {
+        showToast('Name and email are required.', 'error');
+        return;
+      }
+      if (!payload.startDate) {
+        delete payload.startDate;
+      }
+      try {
+        if (id) {
+          delete payload.id;
+          await http(`/api/admin/employees/${id}`, createRequestOptions('PATCH', payload));
+          showToast('Employee updated.', 'success');
+        } else {
+          delete payload.id;
+          await http('/api/admin/employees', createRequestOptions('POST', payload));
+          showToast('Employee created.', 'success');
+        }
+        closeModal();
+        await loadEmployees(state.pagination.page);
+      } catch (error) {
+        showToast(error.message || 'Unable to save employee', 'error');
+      }
+    });
+  }
+
+  if (importButton) {
+    importButton.addEventListener('click', async () => {
+      try {
+        const data = await http('/api/admin/employees/import-from-leadership', createRequestOptions('POST', {}));
+        const createdCount = Number.isFinite(data.createdCount)
+          ? data.createdCount
+          : Number.parseInt(data.createdCount, 10) || 0;
+        const skippedCount = Number.isFinite(data.skippedCount)
+          ? data.skippedCount
+          : Number.parseInt(data.skippedCount, 10) || 0;
+        if (createdCount > 0) {
+          const summary =
+            skippedCount > 0
+              ? `Imported ${createdCount} leaders. Skipped ${skippedCount} existing records.`
+              : `Imported ${createdCount} leaders into the roster.`;
+          showToast(summary, 'success');
+        } else if (skippedCount > 0) {
+          showToast(`All leadership members are already in the roster (${skippedCount} skipped).`, 'info');
+        } else {
+          showToast('No new leaders to import.', 'info');
+        }
+        await loadEmployees(state.pagination.page);
+      } catch (error) {
+        showToast(error.message || 'Import failed', 'error');
+      }
+    });
+  }
+
+  if (newButton) {
+    newButton.addEventListener('click', () => {
+      openModal(null);
+    });
+  }
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      closeDetail();
+      if (modal && !modal.hidden) {
+        closeModal();
+      }
+    }
+  });
+
+  loadEmployees(1);
+})();

--- a/public/js/admin-requests.js
+++ b/public/js/admin-requests.js
@@ -1,0 +1,337 @@
+(() => {
+  const tableBody = document.querySelector('[data-request-rows]');
+  if (!tableBody) {
+    return;
+  }
+
+  const searchInput = document.querySelector('[data-request-search]');
+  const statusFilter = document.querySelector('[data-request-filter="status"]');
+  const typeFilter = document.querySelector('[data-request-filter="type"]');
+  const paginationEl = document.querySelector('[data-request-pagination]');
+  const detailPanel = document.querySelector('[data-request-detail]');
+  const detailComment = detailPanel?.querySelector('[data-decision-comment]');
+  const toastEl = document.querySelector('[data-request-toast]');
+  const csrfToken = window.__CSRF_TOKEN__ || document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+  const state = {
+    requests: [],
+    pagination: { page: 1, pageSize: 15, totalPages: 0, total: 0 },
+    query: { search: '', status: 'pending', type: '' },
+    activeRequestId: null
+  };
+
+  function showToast(message, tone = 'info') {
+    if (!toastEl) return;
+    toastEl.textContent = message;
+    toastEl.classList.remove('is-info', 'is-error', 'is-success');
+    toastEl.classList.add('is-visible');
+    toastEl.classList.add(tone === 'error' ? 'is-error' : tone === 'success' ? 'is-success' : 'is-info');
+    window.clearTimeout(toastEl.dataset.timeoutId);
+    const timeoutId = window.setTimeout(() => {
+      toastEl.classList.remove('is-visible', 'is-info', 'is-error', 'is-success');
+      toastEl.textContent = '';
+    }, 4000);
+    toastEl.dataset.timeoutId = String(timeoutId);
+  }
+
+  function httpOptions(method = 'GET', body) {
+    const headers = { 'CSRF-Token': csrfToken };
+    if (body) {
+      headers['Content-Type'] = 'application/json';
+    }
+    const options = { method, headers };
+    if (body) {
+      options.body = JSON.stringify(body);
+    }
+    return options;
+  }
+
+  async function http(url, options) {
+    const response = await fetch(url, options);
+    if (!response.ok) {
+      const text = await response.text();
+      let message = response.statusText || 'Request failed';
+      try {
+        const payload = JSON.parse(text);
+        message = payload.error || payload.message || message;
+      } catch (error) {
+        // ignore
+      }
+      throw new Error(message);
+    }
+    if (response.status === 204) {
+      return null;
+    }
+    const contentType = response.headers.get('content-type') || '';
+    if (contentType.includes('application/json')) {
+      return response.json();
+    }
+    return response.text();
+  }
+
+  function setLoading(isLoading) {
+    if (!tableBody) return;
+    if (isLoading) {
+      tableBody.innerHTML = '';
+      const row = document.createElement('tr');
+      const cell = document.createElement('td');
+      cell.colSpan = 6;
+      cell.textContent = 'Loading requests…';
+      row.appendChild(cell);
+      tableBody.appendChild(row);
+    }
+  }
+
+  function formatDate(value) {
+    if (!value) return '—';
+    try {
+      return new Date(value).toLocaleString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit'
+      });
+    } catch (error) {
+      return value;
+    }
+  }
+
+  function renderRequests() {
+    tableBody.innerHTML = '';
+    if (!state.requests.length) {
+      const row = document.createElement('tr');
+      const cell = document.createElement('td');
+      cell.colSpan = 6;
+      cell.textContent = state.query.status === 'pending'
+        ? 'No pending requests at the moment.'
+        : 'No requests match the filters.';
+      row.appendChild(cell);
+      tableBody.appendChild(row);
+      return;
+    }
+
+    state.requests.forEach((request) => {
+      const row = document.createElement('tr');
+      row.dataset.requestId = request.id;
+
+      const employeeCell = document.createElement('td');
+      const stack = document.createElement('div');
+      stack.className = 'stacked';
+      const name = document.createElement('strong');
+      name.textContent = request.employee?.name || 'Unknown employee';
+      const email = document.createElement('span');
+      email.className = 'muted';
+      email.textContent = request.employee?.email || '—';
+      stack.appendChild(name);
+      stack.appendChild(email);
+      employeeCell.appendChild(stack);
+      row.appendChild(employeeCell);
+
+      const typeCell = document.createElement('td');
+      typeCell.textContent = request.type;
+      row.appendChild(typeCell);
+
+      const submittedCell = document.createElement('td');
+      submittedCell.textContent = formatDate(request.createdAt);
+      row.appendChild(submittedCell);
+
+      const statusCell = document.createElement('td');
+      const chip = document.createElement('span');
+      chip.className = `status-chip status-${request.status}`;
+      chip.textContent = request.status;
+      statusCell.appendChild(chip);
+      row.appendChild(statusCell);
+
+      const commentCell = document.createElement('td');
+      commentCell.textContent = request.comment || '—';
+      row.appendChild(commentCell);
+
+      const actionsCell = document.createElement('td');
+      const reviewButton = document.createElement('button');
+      reviewButton.type = 'button';
+      reviewButton.className = 'pill-link secondary';
+      reviewButton.textContent = 'Review';
+      reviewButton.addEventListener('click', () => {
+        openDetail(request);
+      });
+      actionsCell.appendChild(reviewButton);
+      row.appendChild(actionsCell);
+
+      tableBody.appendChild(row);
+    });
+  }
+
+  function updatePagination() {
+    if (!paginationEl) return;
+    const prev = paginationEl.querySelector('[data-page="prev"]');
+    const next = paginationEl.querySelector('[data-page="next"]');
+    const status = paginationEl.querySelector('[data-page-status]');
+    if (prev) {
+      prev.disabled = state.pagination.page <= 1;
+    }
+    if (next) {
+      next.disabled = state.pagination.totalPages === 0 || state.pagination.page >= state.pagination.totalPages;
+    }
+    if (status) {
+      status.textContent = `Page ${state.pagination.totalPages === 0 ? 0 : state.pagination.page} of ${state.pagination.totalPages}`;
+    }
+  }
+
+  function formatPayload(payload) {
+    if (!payload || typeof payload !== 'object') {
+      return '—';
+    }
+    const entries = Object.entries(payload);
+    if (!entries.length) {
+      return '—';
+    }
+    const list = document.createElement('ul');
+    list.className = 'payload-list';
+    entries.forEach(([key, value]) => {
+      const item = document.createElement('li');
+      item.innerHTML = `<strong>${key}</strong>: ${value ?? '—'}`;
+      list.appendChild(item);
+    });
+    return list.outerHTML;
+  }
+
+  function openDetail(request) {
+    if (!detailPanel) return;
+    state.activeRequestId = request.id;
+    detailPanel.querySelector('[data-detail-title]').textContent = `${request.type} request`;
+    detailPanel.querySelector('[data-detail-subtitle]').textContent = `${request.employee?.name || 'Unknown'} • ${formatDate(request.createdAt)}`;
+    detailPanel.querySelector('[data-detail-employee]').textContent = request.employee?.name || '—';
+    detailPanel.querySelector('[data-detail-department]').textContent = request.employee?.department || '—';
+    detailPanel.querySelector('[data-detail-status]').textContent = request.status;
+    detailPanel.querySelector('[data-detail-created]').textContent = formatDate(request.createdAt);
+    const payloadEl = detailPanel.querySelector('[data-detail-payload]');
+    payloadEl.innerHTML = formatPayload(request.payload);
+    if (detailComment) {
+      detailComment.value = request.comment || '';
+    }
+    detailPanel.hidden = false;
+  }
+
+  function closeDetail() {
+    if (!detailPanel) return;
+    detailPanel.hidden = true;
+    state.activeRequestId = null;
+    if (detailComment) {
+      detailComment.value = '';
+    }
+  }
+
+  async function loadRequests(page = 1) {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams();
+      params.set('page', page);
+      params.set('pageSize', state.pagination.pageSize);
+      if (state.query.search) params.set('search', state.query.search);
+      if (state.query.status) params.set('status', state.query.status);
+      if (state.query.type) params.set('type', state.query.type);
+      const data = await http(`/api/admin/employee-requests?${params.toString()}`);
+      state.requests = data.requests || [];
+      state.pagination = data.pagination || state.pagination;
+      state.pagination.page = data.pagination?.page || page;
+      renderRequests();
+      updatePagination();
+      if (state.activeRequestId) {
+        const match = state.requests.find((item) => item.id === state.activeRequestId);
+        if (match) {
+          openDetail(match);
+        } else {
+          closeDetail();
+        }
+      }
+    } catch (error) {
+      showToast(error.message || 'Unable to load requests', 'error');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function submitDecision(status) {
+    if (!state.activeRequestId) {
+      showToast('Select a request to review.', 'error');
+      return;
+    }
+    try {
+      const body = { status, comment: detailComment?.value || '' };
+      await http(`/api/admin/employee-requests/${state.activeRequestId}/decision`, httpOptions('POST', body));
+      showToast(`Request ${status === 'approved' ? 'approved' : 'denied'}.`, 'success');
+      closeDetail();
+      await loadRequests(state.pagination.page);
+    } catch (error) {
+      showToast(error.message || 'Unable to record decision', 'error');
+    }
+  }
+
+  let searchTimeout;
+  if (searchInput) {
+    searchInput.addEventListener('input', (event) => {
+      window.clearTimeout(searchTimeout);
+      const value = event.target.value.trim();
+      searchTimeout = window.setTimeout(() => {
+        state.query.search = value;
+        state.pagination.page = 1;
+        loadRequests(1);
+      }, 250);
+    });
+  }
+
+  if (statusFilter) {
+    statusFilter.addEventListener('change', (event) => {
+      state.query.status = event.target.value;
+      state.pagination.page = 1;
+      loadRequests(1);
+    });
+  }
+
+  if (typeFilter) {
+    typeFilter.addEventListener('change', (event) => {
+      state.query.type = event.target.value;
+      state.pagination.page = 1;
+      loadRequests(1);
+    });
+  }
+
+  if (paginationEl) {
+    paginationEl.addEventListener('click', (event) => {
+      const button = event.target.closest('button[data-page]');
+      if (!button) return;
+      const direction = button.dataset.page;
+      if (direction === 'prev' && state.pagination.page > 1) {
+        loadRequests(state.pagination.page - 1);
+      } else if (direction === 'next' && state.pagination.page < state.pagination.totalPages) {
+        loadRequests(state.pagination.page + 1);
+      }
+    });
+  }
+
+  if (detailPanel) {
+    detailPanel.querySelector('[data-close-request]')?.addEventListener('click', () => {
+      closeDetail();
+    });
+    detailPanel.querySelector('[data-decision="approve"]')?.addEventListener('click', () => {
+      submitDecision('approved');
+    });
+    detailPanel.querySelector('[data-decision="deny"]')?.addEventListener('click', () => {
+      submitDecision('denied');
+    });
+  }
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      closeDetail();
+    }
+  });
+
+  // Default status filter to pending for first load.
+  if (statusFilter) {
+    statusFilter.value = 'pending';
+  }
+
+  loadRequests(1);
+})();

--- a/src/app.js
+++ b/src/app.js
@@ -25,6 +25,7 @@ const adminRoutes = require('./routes/admin');
 const diningRoutes = require('./routes/dining');
 const adminDiningRoutes = require('./routes/adminDining');
 const adminApiRoutes = require('./routes/adminApi');
+const employeeRequestRoutes = require('./routes/employeeRequests');
 
 const app = express();
 const isProd = process.env.NODE_ENV === 'production';
@@ -170,6 +171,7 @@ app.use((req, res, next) => {
 });
 
 app.use('/api/admin', adminApiRoutes);
+app.use('/api/employee/requests', employeeRequestRoutes);
 
 const buildLimiter = ({ windowMs, max, skipSuccessfulRequests = false, message }) => {
   const retryAfterSeconds = Math.ceil(windowMs / 1000);

--- a/src/data/leadership.js
+++ b/src/data/leadership.js
@@ -1,0 +1,62 @@
+const boardMembers = [
+  {
+    name: 'Dr. Selene Kaori',
+    role: 'Chair, Board of Directors',
+    focus: 'Guiding interstellar expansion and ethical hospitality.',
+    contact: 'selene.kaori@auroranexus.com'
+  },
+  {
+    name: 'Adrian Volkov',
+    role: 'Director of Galactic Partnerships',
+    focus: 'Cultivating alliances with orbital authorities and ports of call.',
+    contact: 'avolkov@auroranexus.com'
+  },
+  {
+    name: 'Evelyn Singh',
+    role: 'Director of Sustainability',
+    focus: 'Ensuring zero-waste operations across every stratospheric hub.',
+    contact: 'e.singh@auroranexus.com'
+  }
+];
+
+const executiveTeam = [
+  {
+    name: 'Harshit Garg',
+    role: 'Chief Experience Officer',
+    focus: 'Architecting guest journeys that feel telepathic.',
+    contact: 'hgarg@auroranexus.com'
+  },
+  {
+    name: 'Nova Ortega',
+    role: 'General Manager',
+    focus: 'Operational excellence from lobby drones to orbit shuttles.',
+    contact: 'nova.ortega@auroranexus.com'
+  },
+  {
+    name: 'Ilya Rosenthal',
+    role: 'Director of Concierge Intelligence',
+    focus: 'Orchestrating the live chat concierges and predictive care.',
+    contact: 'ilya.rosenthal@auroranexus.com'
+  }
+];
+
+const advisoryCouncil = [
+  {
+    name: 'Professor Amara Qadir',
+    role: 'Spatial Design Advisor',
+    focus: 'Crafting biophilic suites with zero-gravity comfort.',
+    contact: 'amara.qadir@auroranexus.com'
+  },
+  {
+    name: 'Captain Idris Vale',
+    role: 'Orbital Logistics Advisor',
+    focus: 'Synchronising docking windows and arrival flotillas.',
+    contact: 'idris.vale@auroranexus.com'
+  }
+];
+
+module.exports = {
+  boardMembers,
+  executiveTeam,
+  advisoryCouncil
+};

--- a/src/models/employeeRequests.js
+++ b/src/models/employeeRequests.js
@@ -1,0 +1,174 @@
+const { v4: uuidv4 } = require('uuid');
+const { getDb } = require('../db');
+
+const db = getDb();
+
+function parsePayload(value) {
+  if (!value) {
+    return {};
+  }
+  if (typeof value === 'object') {
+    return value;
+  }
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    return {};
+  }
+}
+
+function serializeRequest(row) {
+  if (!row) {
+    return null;
+  }
+  return {
+    id: row.id,
+    employeeId: row.employeeId,
+    userId: row.userId,
+    type: row.type,
+    payload: parsePayload(row.payload),
+    status: row.status,
+    comment: row.comment,
+    decisionByUserId: row.decisionByUserId,
+    decisionAt: row.decisionAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    employee: row.employeeId
+      ? {
+          id: row.employeeId,
+          name: row.employeeName,
+          email: row.employeeEmail,
+          department: row.employeeDepartment,
+          status: row.employeeStatus
+        }
+      : null
+  };
+}
+
+function normalisePage(value, fallback) {
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed < 1) {
+    return fallback;
+  }
+  return parsed;
+}
+
+function normalisePageSize(value, fallback) {
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed < 1) {
+    return fallback;
+  }
+  return Math.min(parsed, 100);
+}
+
+function createRequest({ employeeId, userId, type, payload }) {
+  const now = new Date().toISOString();
+  const record = {
+    id: uuidv4(),
+    employeeId,
+    userId: userId || null,
+    type,
+    payload: JSON.stringify(payload || {}),
+    status: 'pending',
+    comment: null,
+    decisionByUserId: null,
+    decisionAt: null,
+    createdAt: now,
+    updatedAt: now
+  };
+  db.prepare(`
+    INSERT INTO employee_requests (id, employeeId, userId, type, payload, status, comment, decisionByUserId, decisionAt, createdAt, updatedAt)
+    VALUES (@id, @employeeId, @userId, @type, @payload, @status, @comment, @decisionByUserId, @decisionAt, @createdAt, @updatedAt)
+  `).run(record);
+  return getRequestById(record.id);
+}
+
+function getRequestById(id) {
+  const row = db
+    .prepare(
+      `SELECT er.*, e.name as employeeName, e.email as employeeEmail, e.department as employeeDepartment, e.status as employeeStatus
+       FROM employee_requests er
+       LEFT JOIN employees e ON e.id = er.employeeId
+       WHERE er.id = ?`
+    )
+    .get(id);
+  return serializeRequest(row);
+}
+
+function listRequests(options = {}) {
+  const page = normalisePage(options.page, 1);
+  const pageSize = normalisePageSize(options.pageSize, 20);
+  const conditions = [];
+  const values = [];
+  if (options.status) {
+    conditions.push('LOWER(er.status) = ?');
+    values.push(String(options.status).toLowerCase());
+  }
+  if (options.type) {
+    conditions.push('LOWER(er.type) = ?');
+    values.push(String(options.type).toLowerCase());
+  }
+  if (options.search) {
+    const like = `%${String(options.search).toLowerCase()}%`;
+    conditions.push('(LOWER(e.name) LIKE ? OR LOWER(e.email) LIKE ? OR LOWER(er.type) LIKE ?)');
+    values.push(like, like, like);
+  }
+  const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+  const baseQuery = `FROM employee_requests er LEFT JOIN employees e ON e.id = er.employeeId ${where}`;
+  const total = db.prepare(`SELECT COUNT(*) as count ${baseQuery}`).get(...values).count;
+  const offset = (page - 1) * pageSize;
+  const rows = db
+    .prepare(
+      `SELECT er.*, e.name as employeeName, e.email as employeeEmail, e.department as employeeDepartment, e.status as employeeStatus
+       ${baseQuery}
+       ORDER BY er.createdAt DESC
+       LIMIT ? OFFSET ?`
+    )
+    .all(...values, pageSize, offset);
+  return {
+    requests: rows.map(serializeRequest),
+    pagination: {
+      page,
+      pageSize,
+      total,
+      totalPages: total === 0 ? 0 : Math.ceil(total / pageSize)
+    }
+  };
+}
+
+function listPendingRequestsByEmployee(employeeId, type) {
+  const rows = db
+    .prepare(
+      `SELECT er.*, e.name as employeeName, e.email as employeeEmail, e.department as employeeDepartment, e.status as employeeStatus
+       FROM employee_requests er
+       LEFT JOIN employees e ON e.id = er.employeeId
+       WHERE er.employeeId = ? AND er.status = 'pending' AND er.type = ?
+       ORDER BY er.createdAt DESC`
+    )
+    .all(employeeId, type);
+  return rows.map(serializeRequest);
+}
+
+function updateRequestStatus(id, status, comment, decisionByUserId) {
+  const existing = getRequestById(id);
+  if (!existing) {
+    const error = new Error('Request not found');
+    error.status = 404;
+    throw error;
+  }
+  const now = new Date().toISOString();
+  db.prepare(
+    `UPDATE employee_requests
+     SET status = ?, comment = ?, decisionByUserId = ?, decisionAt = ?, updatedAt = ?
+     WHERE id = ?`
+  ).run(status, comment || null, decisionByUserId || null, now, now, id);
+  return getRequestById(id);
+}
+
+module.exports = {
+  createRequest,
+  getRequestById,
+  listRequests,
+  listPendingRequestsByEmployee,
+  updateRequestStatus
+};

--- a/src/models/employees.js
+++ b/src/models/employees.js
@@ -1,0 +1,290 @@
+const { v4: uuidv4 } = require('uuid');
+const { getDb } = require('../db');
+
+const db = getDb();
+
+function serializeEmployee(row) {
+  if (!row) {
+    return null;
+  }
+  return {
+    id: row.id,
+    name: row.name,
+    email: row.email,
+    phone: row.phone,
+    department: row.department,
+    title: row.title,
+    employmentType: row.employmentType,
+    startDate: row.startDate,
+    status: row.status,
+    emergencyContact: row.emergencyContact,
+    notes: row.notes,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt
+  };
+}
+
+function normalisePage(value, fallback) {
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed < 1) {
+    return fallback;
+  }
+  return parsed;
+}
+
+function normalisePageSize(value, fallback) {
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed < 1) {
+    return fallback;
+  }
+  return Math.min(parsed, 100);
+}
+
+function buildWhereClause({ search, department, status, employmentType }) {
+  const conditions = [];
+  const values = [];
+  if (search) {
+    const like = `%${search.toLowerCase()}%`;
+    conditions.push('(LOWER(name) LIKE ? OR LOWER(email) LIKE ? OR LOWER(department) LIKE ? OR LOWER(title) LIKE ?)');
+    values.push(like, like, like, like);
+  }
+  if (department) {
+    conditions.push('LOWER(department) = ?');
+    values.push(department.toLowerCase());
+  }
+  if (status) {
+    conditions.push('LOWER(status) = ?');
+    values.push(status.toLowerCase());
+  }
+  if (employmentType) {
+    conditions.push('LOWER(employmentType) = ?');
+    values.push(employmentType.toLowerCase());
+  }
+  const whereClause = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+  return { whereClause, values };
+}
+
+function listEmployees(options = {}) {
+  const page = normalisePage(options.page, 1);
+  const pageSize = normalisePageSize(options.pageSize, 20);
+  const { whereClause, values } = buildWhereClause(options);
+  const offset = (page - 1) * pageSize;
+  const countStmt = db.prepare(`SELECT COUNT(*) as count FROM employees ${whereClause}`);
+  const total = countStmt.get(...values).count;
+  const dataStmt = db.prepare(
+    `SELECT * FROM employees ${whereClause} ORDER BY LOWER(name) ASC LIMIT ? OFFSET ?`
+  );
+  const rows = dataStmt.all(...values, pageSize, offset);
+  return {
+    employees: rows.map(serializeEmployee),
+    pagination: {
+      page,
+      pageSize,
+      total,
+      totalPages: total === 0 ? 0 : Math.ceil(total / pageSize)
+    }
+  };
+}
+
+function getEmployeeById(id) {
+  const row = db.prepare('SELECT * FROM employees WHERE id = ?').get(id);
+  return serializeEmployee(row);
+}
+
+function getEmployeeByEmail(email) {
+  if (!email) {
+    return null;
+  }
+  const row = db.prepare('SELECT * FROM employees WHERE LOWER(email) = LOWER(?)').get(email);
+  return serializeEmployee(row);
+}
+
+function createEmployee(payload) {
+  const existing = getEmployeeByEmail(payload.email);
+  if (existing) {
+    const error = new Error('An employee record already exists for that email address.');
+    error.status = 409;
+    throw error;
+  }
+  const now = new Date().toISOString();
+  const record = {
+    id: uuidv4(),
+    name: payload.name,
+    email: payload.email.toLowerCase(),
+    phone: payload.phone || null,
+    department: payload.department || null,
+    title: payload.title || null,
+    employmentType: payload.employmentType || 'Full-Time',
+    startDate: payload.startDate || null,
+    status: payload.status || 'active',
+    emergencyContact: payload.emergencyContact || null,
+    notes: payload.notes || null,
+    createdAt: now,
+    updatedAt: now
+  };
+  db.prepare(`
+    INSERT INTO employees (id, name, email, phone, department, title, employmentType, startDate, status, emergencyContact, notes, createdAt, updatedAt)
+    VALUES (@id, @name, @email, @phone, @department, @title, @employmentType, @startDate, @status, @emergencyContact, @notes, @createdAt, @updatedAt)
+  `).run(record);
+  return serializeEmployee(record);
+}
+
+function updateEmployee(id, updates = {}) {
+  const existing = getEmployeeById(id);
+  if (!existing) {
+    const error = new Error('Employee not found');
+    error.status = 404;
+    throw error;
+  }
+  const fields = [];
+  const values = [];
+  const allowed = [
+    'name',
+    'email',
+    'phone',
+    'department',
+    'title',
+    'employmentType',
+    'startDate',
+    'status',
+    'emergencyContact',
+    'notes'
+  ];
+  allowed.forEach((field) => {
+    if (Object.prototype.hasOwnProperty.call(updates, field)) {
+      if (field === 'email' && updates.email) {
+        const lower = updates.email.toLowerCase();
+        if (lower !== existing.email.toLowerCase()) {
+          const other = getEmployeeByEmail(lower);
+          if (other && other.id !== id) {
+            const error = new Error('Another employee already uses that email address.');
+            error.status = 409;
+            throw error;
+          }
+        }
+        values.push(lower);
+      } else {
+        values.push(updates[field] ?? null);
+      }
+      fields.push(`${field} = ?`);
+    }
+  });
+  if (!fields.length) {
+    return existing;
+  }
+  values.push(new Date().toISOString());
+  values.push(id);
+  db.prepare(
+    `UPDATE employees SET ${fields.join(', ')}, updatedAt = ? WHERE id = ?`
+  ).run(...values);
+  return getEmployeeById(id);
+}
+
+function deleteEmployee(id) {
+  const existing = getEmployeeById(id);
+  if (!existing) {
+    return false;
+  }
+  db.prepare('DELETE FROM employees WHERE id = ?').run(id);
+  return true;
+}
+
+function bulkUpdateEmployees(ids = [], updates = {}) {
+  if (!Array.isArray(ids) || ids.length === 0) {
+    return { updated: 0 };
+  }
+  const allowed = ['department', 'status'];
+  const fields = [];
+  const values = [];
+  allowed.forEach((field) => {
+    if (Object.prototype.hasOwnProperty.call(updates, field)) {
+      fields.push(`${field} = ?`);
+      values.push(updates[field] ?? null);
+    }
+  });
+  if (!fields.length) {
+    return { updated: 0 };
+  }
+  const placeholders = ids.map(() => '?').join(',');
+  const stmt = db.prepare(
+    `UPDATE employees SET ${fields.join(', ')}, updatedAt = ? WHERE id IN (${placeholders})`
+  );
+  const result = stmt.run(...values, new Date().toISOString(), ...ids);
+  return { updated: result.changes };
+}
+
+function listEmployeeFilters() {
+  const departments = db
+    .prepare(
+      "SELECT DISTINCT department FROM employees WHERE department IS NOT NULL AND department != '' ORDER BY LOWER(department) ASC"
+    )
+    .all()
+    .map((row) => row.department);
+  const statuses = db
+    .prepare(
+      "SELECT DISTINCT status FROM employees WHERE status IS NOT NULL AND status != '' ORDER BY LOWER(status) ASC"
+    )
+    .all()
+    .map((row) => row.status);
+  const employmentTypes = db
+    .prepare(
+      "SELECT DISTINCT employmentType FROM employees WHERE employmentType IS NOT NULL AND employmentType != '' ORDER BY LOWER(employmentType) ASC"
+    )
+    .all()
+    .map((row) => row.employmentType);
+  return { departments, statuses, employmentTypes };
+}
+
+function importLeadership(entries = []) {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return { created: [], skipped: [] };
+  }
+  const insertStmt = db.prepare(`
+    INSERT INTO employees (id, name, email, phone, department, title, employmentType, startDate, status, emergencyContact, notes, createdAt, updatedAt)
+    VALUES (@id, @name, @email, @phone, @department, @title, @employmentType, @startDate, @status, @emergencyContact, @notes, @createdAt, @updatedAt)
+  `);
+  const created = [];
+  const skipped = [];
+  const today = new Date().toISOString().slice(0, 10);
+  const now = new Date().toISOString();
+  const txn = db.transaction((payloads) => {
+    payloads.forEach((entry) => {
+      const lowerEmail = String(entry.email || '').toLowerCase();
+      if (!lowerEmail || getEmployeeByEmail(lowerEmail)) {
+        skipped.push(lowerEmail);
+        return;
+      }
+      const record = {
+        id: uuidv4(),
+        name: entry.name,
+        email: lowerEmail,
+        phone: entry.phone || null,
+        department: entry.department || null,
+        title: entry.title || null,
+        employmentType: entry.employmentType || 'Full-Time',
+        startDate: entry.startDate || today,
+        status: entry.status || 'active',
+        emergencyContact: entry.emergencyContact || null,
+        notes: entry.notes || `Imported from leadership directory on ${today}.`,
+        createdAt: now,
+        updatedAt: now
+      };
+      insertStmt.run(record);
+      created.push(serializeEmployee(record));
+    });
+  });
+  txn(entries);
+  return { created, skipped };
+}
+
+module.exports = {
+  listEmployees,
+  getEmployeeById,
+  getEmployeeByEmail,
+  createEmployee,
+  updateEmployee,
+  deleteEmployee,
+  bulkUpdateEmployees,
+  listEmployeeFilters,
+  importLeadership
+};

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -305,4 +305,10 @@ router.post('/admin/inquiries/:id/status', ensureAdmin, (req, res) => {
   return res.redirect('/admin');
 });
 
+router.get('/admin/requests', ensureAdmin, (req, res) => {
+  res.render('admin/requests', {
+    pageTitle: 'Employee Requests Queue'
+  });
+});
+
 module.exports = router;

--- a/src/routes/adminApi.js
+++ b/src/routes/adminApi.js
@@ -1,18 +1,22 @@
 const express = require('express');
 const Joi = require('joi');
+const crypto = require('crypto');
 const {
   requireRole,
   Roles,
   roleHigherThan,
   normalizeRole,
-  getRolePriority
+  getRolePriority,
+  roleAtLeast
 } = require('../utils/rbac');
 const {
   getAllUsers,
   createSubAdmin,
   listSubAdmins,
   getUserById,
-  removeSubAdmin
+  removeSubAdmin,
+  getUserByEmail,
+  updateUserPassword
 } = require('../models/users');
 const {
   getRolePermissions,
@@ -20,6 +24,23 @@ const {
   listRoles
 } = require('../models/roles');
 const { recordAuditLog } = require('../models/auditLogs');
+const {
+  listEmployees,
+  getEmployeeById,
+  createEmployee,
+  updateEmployee,
+  deleteEmployee,
+  bulkUpdateEmployees,
+  listEmployeeFilters,
+  importLeadership
+} = require('../models/employees');
+const {
+  listRequests: listEmployeeRequests,
+  getRequestById,
+  listPendingRequestsByEmployee,
+  updateRequestStatus
+} = require('../models/employeeRequests');
+const { boardMembers, executiveTeam, advisoryCouncil } = require('../data/leadership');
 
 const router = express.Router();
 
@@ -41,7 +62,512 @@ const permissionUpdateSchema = Joi.object({
   allowed: Joi.boolean().required()
 });
 
+const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+
+const employeeCreateSchema = Joi.object({
+  name: Joi.string().min(2).max(120).required(),
+  email: Joi.string().email({ tlds: { allow: false } }).required(),
+  phone: Joi.string().max(40).allow(null, '').empty(''),
+  department: Joi.string().max(120).allow(null, '').empty(''),
+  title: Joi.string().max(120).allow(null, '').empty(''),
+  employmentType: Joi.string().max(80).allow(null, '').default('Full-Time'),
+  startDate: Joi.string().pattern(datePattern).allow(null, '').empty(''),
+  status: Joi.string().max(40).allow(null, '').empty('').default('active'),
+  emergencyContact: Joi.string().max(160).allow(null, '').empty(''),
+  notes: Joi.string().max(1000).allow(null, '').empty('')
+});
+
+const employeeUpdateSchema = employeeCreateSchema.fork(['name', 'email'], (schema) => schema.optional());
+
+const employeeBulkSchema = Joi.object({
+  ids: Joi.array().items(Joi.string().guid({ version: 'uuidv4' })).min(1).required(),
+  department: Joi.string().max(120).allow(null, '').empty(''),
+  status: Joi.string().max(40).allow(null, '').empty('')
+}).custom((value, helpers) => {
+  if (value.department == null && value.status == null) {
+    return helpers.error('any.custom', { message: 'A department or status update is required.' });
+  }
+  return value;
+}, 'Bulk employee validation');
+
+const leadershipImportSchema = Joi.object({
+  includeAdvisory: Joi.boolean().default(true),
+  includeBoard: Joi.boolean().default(true),
+  includeExecutive: Joi.boolean().default(true)
+});
+
+const requestDecisionSchema = Joi.object({
+  status: Joi.string().valid('approved', 'denied').required(),
+  comment: Joi.string().max(500).allow(null, '').empty('')
+});
+
+const transferApprovalSchema = Joi.object({
+  requestId: Joi.string().guid({ version: 'uuidv4' }).optional(),
+  comment: Joi.string().max(500).allow(null, '').empty('')
+});
+
+function buildLeadershipEntries(options) {
+  const entries = [];
+  const today = new Date().toISOString().slice(0, 10);
+  if (options.includeBoard) {
+    boardMembers.forEach((member) => {
+      entries.push({
+        name: member.name,
+        email: member.contact,
+        title: member.role,
+        department: 'Board of Directors',
+        employmentType: 'Full-Time',
+        status: 'active',
+        startDate: today,
+        notes: member.focus
+      });
+    });
+  }
+  if (options.includeExecutive) {
+    executiveTeam.forEach((member) => {
+      entries.push({
+        name: member.name,
+        email: member.contact,
+        title: member.role,
+        department: 'Executive Team',
+        employmentType: 'Full-Time',
+        status: 'active',
+        startDate: today,
+        notes: member.focus
+      });
+    });
+  }
+  if (options.includeAdvisory) {
+    advisoryCouncil.forEach((member) => {
+      entries.push({
+        name: member.name,
+        email: member.contact,
+        title: member.role,
+        department: 'Advisory Council',
+        employmentType: 'Contract',
+        status: 'active',
+        startDate: today,
+        notes: member.focus
+      });
+    });
+  }
+  return entries;
+}
+
+function generateTemporaryPassword() {
+  const raw = crypto.randomBytes(9).toString('base64');
+  return raw.replace(/[^a-zA-Z0-9]/g, '').slice(0, 12) || 'Skyhaven123';
+}
+
+function resolvePendingRequest(employeeId, type, requestId) {
+  if (requestId) {
+    const request = getRequestById(requestId);
+    if (!request || request.employeeId !== employeeId || request.type !== type || request.status !== 'pending') {
+      const error = new Error('Matching pending request not found for this employee.');
+      error.status = 404;
+      throw error;
+    }
+    return request;
+  }
+  const [latest] = listPendingRequestsByEmployee(employeeId, type);
+  if (!latest) {
+    const error = new Error('No pending request found for this employee.');
+    error.status = 404;
+    throw error;
+  }
+  return latest;
+}
+
+function approveTransfer({ employeeId, actorUserId, request, comment }) {
+  const payload = request.payload || {};
+  const updates = {};
+  if (payload.targetDepartment) {
+    updates.department = payload.targetDepartment;
+  }
+  if (payload.targetStatus) {
+    updates.status = payload.targetStatus;
+  }
+  let updatedEmployee = getEmployeeById(employeeId);
+  if (!updatedEmployee) {
+    const error = new Error('Employee not found');
+    error.status = 404;
+    throw error;
+  }
+  if (Object.keys(updates).length > 0) {
+    updatedEmployee = updateEmployee(employeeId, updates);
+  }
+  const updatedRequest = updateRequestStatus(request.id, 'approved', comment, actorUserId);
+  const linkedUser = updatedEmployee?.email ? getUserByEmail(updatedEmployee.email) : null;
+  recordAuditLog({
+    actorUserId,
+    targetUserId: linkedUser?.id || null,
+    action: 'employee_transfer_approved',
+    details: {
+      employeeId,
+      requestId: request.id,
+      targetDepartment: updates.department || updatedEmployee.department,
+      payload
+    }
+  });
+  return { employee: updatedEmployee, request: updatedRequest };
+}
+
+function approveResignation({ employeeId, actorUserId, request, comment }) {
+  const existing = getEmployeeById(employeeId);
+  if (!existing) {
+    const error = new Error('Employee not found');
+    error.status = 404;
+    throw error;
+  }
+  const updatedEmployee = updateEmployee(employeeId, { status: 'terminated' });
+  const updatedRequest = updateRequestStatus(request.id, 'approved', comment, actorUserId);
+  const linkedUser = updatedEmployee?.email ? getUserByEmail(updatedEmployee.email) : null;
+  const payload = request.payload || {};
+  recordAuditLog({
+    actorUserId,
+    targetUserId: linkedUser?.id || null,
+    action: 'employee_resignation_approved',
+    details: {
+      employeeId,
+      requestId: request.id,
+      effectiveLastDay: payload.lastDay || null,
+      reason: payload.reason || null
+    }
+  });
+  recordAuditLog({
+    actorUserId,
+    targetUserId: linkedUser?.id || null,
+    action: 'employee_termination',
+    details: {
+      employeeId,
+      source: 'resignation_approval',
+      requestId: request.id
+    }
+  });
+  return { employee: updatedEmployee, request: updatedRequest };
+}
+
 router.use(requireRole(Roles.ADMIN));
+
+router.get('/employees', (req, res) => {
+  const search = typeof req.query.search === 'string' ? req.query.search.trim() : undefined;
+  const department = typeof req.query.department === 'string' ? req.query.department.trim() : undefined;
+  const status = typeof req.query.status === 'string' ? req.query.status.trim() : undefined;
+  const employmentType =
+    typeof req.query.employmentType === 'string' ? req.query.employmentType.trim() : undefined;
+  const { employees, pagination } = listEmployees({
+    search,
+    department,
+    status,
+    employmentType,
+    page: req.query.page,
+    pageSize: req.query.pageSize
+  });
+  const filters = listEmployeeFilters();
+  return res.json({
+    employees,
+    pagination,
+    filters
+  });
+});
+
+router.post('/employees', (req, res) => {
+  const { error, value } = employeeCreateSchema.validate(req.body, {
+    abortEarly: false,
+    stripUnknown: true
+  });
+  if (error) {
+    return res.status(400).json({
+      error: 'Invalid employee payload',
+      details: error.details.map((detail) => detail.message)
+    });
+  }
+  try {
+    const employee = createEmployee(value);
+    return res.status(201).json({ employee });
+  } catch (creationError) {
+    const status = creationError.status || 500;
+    return res.status(status).json({ error: creationError.message || 'Unable to create employee' });
+  }
+});
+
+router.patch('/employees/:id', (req, res) => {
+  const employeeId = String(req.params.id || '').trim();
+  if (!employeeId) {
+    return res.status(400).json({ error: 'Employee id is required' });
+  }
+  const { error, value } = employeeUpdateSchema.validate(req.body, {
+    abortEarly: false,
+    stripUnknown: true
+  });
+  if (error) {
+    return res.status(400).json({
+      error: 'Invalid employee payload',
+      details: error.details.map((detail) => detail.message)
+    });
+  }
+  try {
+    const employee = updateEmployee(employeeId, value);
+    return res.json({ employee });
+  } catch (updateError) {
+    const status = updateError.status || 500;
+    return res.status(status).json({ error: updateError.message || 'Unable to update employee' });
+  }
+});
+
+router.delete('/employees/:id', (req, res) => {
+  const employeeId = String(req.params.id || '').trim();
+  if (!employeeId) {
+    return res.status(400).json({ error: 'Employee id is required' });
+  }
+  const actorRole = normalizeRole(req.user.role);
+  if (!roleAtLeast(actorRole, Roles.SUPER_ADMIN)) {
+    return res.status(403).json({ error: 'Only Super or Global administrators can delete employees.' });
+  }
+  const employee = getEmployeeById(employeeId);
+  if (!employee) {
+    return res.status(404).json({ error: 'Employee not found' });
+  }
+  deleteEmployee(employeeId);
+  const linkedUser = employee.email ? getUserByEmail(employee.email) : null;
+  recordAuditLog({
+    actorUserId: req.user.id,
+    targetUserId: linkedUser?.id || null,
+    action: 'employee_deleted',
+    details: { employeeId }
+  });
+  return res.json({ success: true });
+});
+
+router.post('/employees/bulk', (req, res) => {
+  const { error, value } = employeeBulkSchema.validate(req.body, {
+    abortEarly: false,
+    stripUnknown: true
+  });
+  if (error) {
+    const customMessage = error.details?.[0]?.context?.message;
+    return res.status(400).json({
+      error: customMessage || 'Invalid bulk update payload',
+      details: error.details.map((detail) => detail.message)
+    });
+  }
+  const updates = {};
+  if (Object.prototype.hasOwnProperty.call(value, 'department')) {
+    updates.department = value.department || null;
+  }
+  if (Object.prototype.hasOwnProperty.call(value, 'status')) {
+    updates.status = value.status || null;
+  }
+  const result = bulkUpdateEmployees(value.ids, updates);
+  const employees = value.ids.map((id) => getEmployeeById(id)).filter(Boolean);
+  return res.json({
+    updated: result.updated,
+    employees
+  });
+});
+
+router.post('/employees/import-from-leadership', (req, res) => {
+  const { error, value } = leadershipImportSchema.validate(req.body || {}, {
+    abortEarly: false,
+    stripUnknown: true
+  });
+  if (error) {
+    return res.status(400).json({ error: 'Invalid import options', details: error.details.map((detail) => detail.message) });
+  }
+  const entries = buildLeadershipEntries(value || {});
+  const summary = importLeadership(entries);
+  if (summary.created.length > 0) {
+    summary.created.forEach((employee) => {
+      const linkedUser = employee.email ? getUserByEmail(employee.email) : null;
+      recordAuditLog({
+        actorUserId: req.user.id,
+        targetUserId: linkedUser?.id || null,
+        action: 'employee_imported',
+        details: { employeeId: employee.id, source: 'leadership_directory' }
+      });
+    });
+  }
+  return res.json({
+    created: summary.created,
+    createdCount: summary.created.length,
+    skippedCount: summary.skipped.filter(Boolean).length
+  });
+});
+
+router.post('/employees/:id/reset-password', (req, res) => {
+  const employeeId = String(req.params.id || '').trim();
+  if (!employeeId) {
+    return res.status(400).json({ error: 'Employee id is required' });
+  }
+  const employee = getEmployeeById(employeeId);
+  if (!employee) {
+    return res.status(404).json({ error: 'Employee not found' });
+  }
+  if (!employee.email) {
+    return res.status(400).json({ error: 'Employee record does not include an email address.' });
+  }
+  const user = getUserByEmail(employee.email);
+  if (!user) {
+    return res.status(404).json({ error: 'No user account linked to that employee email.' });
+  }
+  const temporaryPassword = generateTemporaryPassword();
+  updateUserPassword(user.id, temporaryPassword);
+  recordAuditLog({
+    actorUserId: req.user.id,
+    targetUserId: user.id,
+    action: 'employee_password_reset',
+    details: {
+      employeeId,
+      email: employee.email
+    }
+  });
+  return res.json({
+    employee,
+    temporaryPassword
+  });
+});
+
+router.post('/employees/:id/approve-transfer', (req, res) => {
+  const employeeId = String(req.params.id || '').trim();
+  if (!employeeId) {
+    return res.status(400).json({ error: 'Employee id is required' });
+  }
+  const { error, value } = transferApprovalSchema.validate(req.body || {}, {
+    abortEarly: false,
+    stripUnknown: true
+  });
+  if (error) {
+    return res.status(400).json({ error: 'Invalid approval payload', details: error.details.map((detail) => detail.message) });
+  }
+  try {
+    const request = resolvePendingRequest(employeeId, 'transfer', value.requestId);
+    const result = approveTransfer({
+      employeeId,
+      actorUserId: req.user.id,
+      request,
+      comment: value.comment || null
+    });
+    return res.json(result);
+  } catch (approvalError) {
+    const status = approvalError.status || 500;
+    return res.status(status).json({ error: approvalError.message || 'Unable to approve transfer request' });
+  }
+});
+
+router.post('/employees/:id/approve-resignation', (req, res) => {
+  const employeeId = String(req.params.id || '').trim();
+  if (!employeeId) {
+    return res.status(400).json({ error: 'Employee id is required' });
+  }
+  const { error, value } = transferApprovalSchema.validate(req.body || {}, {
+    abortEarly: false,
+    stripUnknown: true
+  });
+  if (error) {
+    return res.status(400).json({ error: 'Invalid approval payload', details: error.details.map((detail) => detail.message) });
+  }
+  try {
+    const request = resolvePendingRequest(employeeId, 'resignation', value.requestId);
+    const result = approveResignation({
+      employeeId,
+      actorUserId: req.user.id,
+      request,
+      comment: value.comment || null
+    });
+    return res.json(result);
+  } catch (approvalError) {
+    const status = approvalError.status || 500;
+    return res.status(status).json({ error: approvalError.message || 'Unable to approve resignation request' });
+  }
+});
+
+router.get('/employee-requests', (req, res) => {
+  const { requests, pagination } = listEmployeeRequests({
+    status: typeof req.query.status === 'string' ? req.query.status.trim() : undefined,
+    type: typeof req.query.type === 'string' ? req.query.type.trim() : undefined,
+    search: typeof req.query.search === 'string' ? req.query.search.trim() : undefined,
+    page: req.query.page,
+    pageSize: req.query.pageSize
+  });
+  return res.json({ requests, pagination });
+});
+
+router.post('/employee-requests/:id/decision', (req, res) => {
+  const requestId = String(req.params.id || '').trim();
+  if (!requestId) {
+    return res.status(400).json({ error: 'Request id is required' });
+  }
+  const { error, value } = requestDecisionSchema.validate(req.body || {}, {
+    abortEarly: false,
+    stripUnknown: true
+  });
+  if (error) {
+    return res.status(400).json({ error: 'Invalid decision payload', details: error.details.map((detail) => detail.message) });
+  }
+  const request = getRequestById(requestId);
+  if (!request) {
+    return res.status(404).json({ error: 'Request not found' });
+  }
+  if (request.status !== 'pending') {
+    return res.status(400).json({ error: 'Request has already been processed.' });
+  }
+  const comment = value.comment || null;
+  if (value.status === 'approved') {
+    if (request.type === 'transfer') {
+      try {
+        const result = approveTransfer({
+          employeeId: request.employeeId,
+          actorUserId: req.user.id,
+          request,
+          comment
+        });
+        return res.json(result);
+      } catch (approvalError) {
+        const status = approvalError.status || 500;
+        return res.status(status).json({ error: approvalError.message || 'Unable to approve transfer request' });
+      }
+    }
+    if (request.type === 'resignation') {
+      try {
+        const result = approveResignation({
+          employeeId: request.employeeId,
+          actorUserId: req.user.id,
+          request,
+          comment
+        });
+        return res.json(result);
+      } catch (approvalError) {
+        const status = approvalError.status || 500;
+        return res.status(status).json({ error: approvalError.message || 'Unable to approve resignation request' });
+      }
+    }
+    const updated = updateRequestStatus(requestId, 'approved', comment, req.user.id);
+    recordAuditLog({
+      actorUserId: req.user.id,
+      targetUserId: null,
+      action: 'employee_request_approved',
+      details: {
+        requestId,
+        employeeId: request.employeeId,
+        type: request.type
+      }
+    });
+    return res.json({ request: updated });
+  }
+
+  const updated = updateRequestStatus(requestId, 'denied', comment, req.user.id);
+  recordAuditLog({
+    actorUserId: req.user.id,
+    targetUserId: null,
+    action: 'employee_request_denied',
+    details: {
+      requestId,
+      employeeId: request.employeeId,
+      type: request.type
+    }
+  });
+  return res.json({ request: updated });
+});
 
 router.get('/directory', (req, res) => {
   const users = getAllUsers();

--- a/src/routes/employeeRequests.js
+++ b/src/routes/employeeRequests.js
@@ -1,0 +1,91 @@
+const express = require('express');
+const Joi = require('joi');
+const { requireRole, Roles } = require('../utils/rbac');
+const { getEmployeeByEmail } = require('../models/employees');
+const { createRequest } = require('../models/employeeRequests');
+const { recordAuditLog } = require('../models/auditLogs');
+
+const router = express.Router();
+
+const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+
+const ptoSchema = Joi.object({
+  startDate: Joi.string().pattern(datePattern).required(),
+  endDate: Joi.string().pattern(datePattern).required(),
+  reason: Joi.string().max(500).required()
+}).custom((value, helpers) => {
+  if (value.endDate < value.startDate) {
+    return helpers.error('any.invalid', { message: 'End date must be on or after the start date.' });
+  }
+  return value;
+});
+
+const workersCompSchema = Joi.object({
+  incidentDate: Joi.string().pattern(datePattern).required(),
+  description: Joi.string().max(1000).required(),
+  location: Joi.string().max(200).allow(null, '').empty(''),
+  medicalAttention: Joi.boolean().default(false)
+});
+
+const resignationSchema = Joi.object({
+  lastDay: Joi.string().pattern(datePattern).required(),
+  reason: Joi.string().max(500).required()
+});
+
+const transferSchema = Joi.object({
+  targetDepartment: Joi.string().max(120).required(),
+  reason: Joi.string().max(500).required(),
+  targetRole: Joi.string().max(120).allow(null, '').empty('')
+});
+
+router.use(requireRole(Roles.EMPLOYEE));
+
+function locateEmployee(req) {
+  const email = req.user?.email;
+  if (!email) {
+    return null;
+  }
+  return getEmployeeByEmail(email);
+}
+
+function registerRequestRoute(path, type, schema) {
+  router.post(path, (req, res) => {
+    const employee = locateEmployee(req);
+    if (!employee) {
+      return res.status(404).json({ error: 'Employee profile not found for your account.' });
+    }
+    const { error, value } = schema.validate(req.body || {}, {
+      abortEarly: false,
+      stripUnknown: true
+    });
+    if (error) {
+      return res.status(400).json({
+        error: 'Invalid request payload',
+        details: error.details.map((detail) => detail.message)
+      });
+    }
+    const request = createRequest({
+      employeeId: employee.id,
+      userId: req.user.id,
+      type,
+      payload: value
+    });
+    recordAuditLog({
+      actorUserId: req.user.id,
+      targetUserId: req.user.id,
+      action: 'employee_request_submitted',
+      details: {
+        requestId: request.id,
+        type
+      }
+    });
+    return res.status(201).json({ request });
+  });
+}
+
+registerRequestRoute('/pto', 'pto', ptoSchema);
+registerRequestRoute('/workers-comp', 'workers-comp', workersCompSchema);
+registerRequestRoute('/resignation', 'resignation', resignationSchema);
+registerRequestRoute('/transfer', 'transfer', transferSchema);
+
+module.exports = router;

--- a/src/routes/public.js
+++ b/src/routes/public.js
@@ -4,6 +4,7 @@ const { listRoomTypes } = require('../models/rooms');
 const { listAmenities } = require('../models/amenities');
 const { addInquiry } = require('../models/inquiries');
 const { sanitizeString } = require('../utils/sanitize');
+const { boardMembers, executiveTeam, advisoryCouncil } = require('../data/leadership');
 
 const router = express.Router();
 
@@ -113,60 +114,9 @@ router.get('/contact', (req, res) => {
 router.get('/leadership', (req, res) => {
   res.render('leadership', {
     pageTitle: 'Leadership & Visionaries',
-    boardMembers: [
-      {
-        name: 'Dr. Selene Kaori',
-        role: 'Chair, Board of Directors',
-        focus: 'Guiding interstellar expansion and ethical hospitality.',
-        contact: 'selene.kaori@auroranexus.com'
-      },
-      {
-        name: 'Adrian Volkov',
-        role: 'Director of Galactic Partnerships',
-        focus: 'Cultivating alliances with orbital authorities and ports of call.',
-        contact: 'avolkov@auroranexus.com'
-      },
-      {
-        name: 'Evelyn Singh',
-        role: 'Director of Sustainability',
-        focus: 'Ensuring zero-waste operations across every stratospheric hub.',
-        contact: 'e.singh@auroranexus.com'
-      }
-    ],
-    executiveTeam: [
-      {
-        name: 'Harshit Garg',
-        role: 'Chief Experience Officer',
-        focus: 'Architecting guest journeys that feel telepathic.',
-        contact: 'hgarg@auroranexus.com'
-      },
-      {
-        name: 'Nova Ortega',
-        role: 'General Manager',
-        focus: 'Operational excellence from lobby drones to orbit shuttles.',
-        contact: 'nova.ortega@auroranexus.com'
-      },
-      {
-        name: 'Ilya Rosenthal',
-        role: 'Director of Concierge Intelligence',
-        focus: 'Orchestrating the live chat concierges and predictive care.',
-        contact: 'ilya.rosenthal@auroranexus.com'
-      }
-    ],
-    advisoryCouncil: [
-      {
-        name: 'Professor Amara Qadir',
-        role: 'Spatial Design Advisor',
-        focus: 'Crafting biophilic suites with zero-gravity comfort.',
-        contact: 'amara.qadir@auroranexus.com'
-      },
-      {
-        name: 'Captain Idris Vale',
-        role: 'Orbital Logistics Advisor',
-        focus: 'Synchronising docking windows and arrival flotillas.',
-        contact: 'idris.vale@auroranexus.com'
-      }
-    ]
+    boardMembers,
+    executiveTeam,
+    advisoryCouncil
   });
 });
 

--- a/views/admin/index.ejs
+++ b/views/admin/index.ejs
@@ -1,11 +1,135 @@
 <%- include('../partials/head', { pageTitle, hotelName, csrfToken, darkMode }) %>
 <script defer src="/js/admin-dining-console.js"></script>
+<script defer src="/js/admin-employees.js"></script>
 <%- include('../partials/nav') %>
 <%- include('../partials/alerts') %>
 
 <section class="admin" data-animate="fade-up">
   <h1>Control deck</h1>
   <p>Monitor inventory, track bookings, and respond to guest signals across <%= hotelName %>.</p>
+
+  <section class="admin-panel admin-panel--employees" data-employee-console>
+    <header class="employees-header">
+      <div>
+        <h2>Employee management</h2>
+        <p>Maintain workforce records, trigger lifecycle workflows, and respond to employee requests.</p>
+      </div>
+      <div class="employees-actions">
+        <a class="pill-link" href="/admin/requests">Review requests</a>
+        <button type="button" class="pill-link secondary" data-import-leadership>Import from Leadership</button>
+        <button type="button" class="pill-link primary" data-open-create>New employee</button>
+      </div>
+    </header>
+
+    <div class="employees-toolbar">
+      <div class="toolbar-search">
+        <label class="sr-only" for="employee-search">Search employees</label>
+        <input id="employee-search" type="search" placeholder="Search name, email, or department" data-employee-search />
+      </div>
+      <div class="toolbar-filters">
+        <label class="sr-only" for="employee-filter-department">Filter by department</label>
+        <select id="employee-filter-department" data-employee-filter="department">
+          <option value="">All departments</option>
+        </select>
+        <label class="sr-only" for="employee-filter-status">Filter by status</label>
+        <select id="employee-filter-status" data-employee-filter="status">
+          <option value="">All statuses</option>
+        </select>
+        <label class="sr-only" for="employee-filter-type">Filter by employment type</label>
+        <select id="employee-filter-type" data-employee-filter="employmentType">
+          <option value="">All employment types</option>
+        </select>
+      </div>
+    </div>
+
+    <form class="employees-bulk" data-employee-bulk>
+      <div class="bulk-field">
+        <label class="sr-only" for="bulk-department">Bulk department</label>
+        <select id="bulk-department" data-bulk-department>
+          <option value="">Set department…</option>
+        </select>
+      </div>
+      <div class="bulk-field">
+        <label class="sr-only" for="bulk-status">Bulk status</label>
+        <select id="bulk-status" data-bulk-status>
+          <option value="">Set status…</option>
+          <option value="active">Active</option>
+          <option value="on-leave">On leave</option>
+          <option value="suspended">Suspended</option>
+          <option value="terminated">Terminated</option>
+        </select>
+      </div>
+      <button type="submit" class="pill-link secondary" data-bulk-apply disabled>Apply to selected</button>
+    </form>
+
+    <div class="employee-table-wrapper">
+      <table class="admin-table employee-table">
+        <thead>
+          <tr>
+            <th scope="col"><span class="sr-only">Select employee</span></th>
+            <th scope="col">Name &amp; contact</th>
+            <th scope="col">Title</th>
+            <th scope="col">Department</th>
+            <th scope="col">Employment</th>
+            <th scope="col">Status</th>
+            <th scope="col">Start</th>
+            <th scope="col">Actions</th>
+          </tr>
+        </thead>
+        <tbody data-employee-rows>
+          <tr data-empty>
+            <td colspan="8">Loading employee roster…</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="employee-pagination" data-employee-pagination>
+      <button type="button" class="pill-link secondary" data-page="prev" disabled>Previous</button>
+      <span data-page-status>Page 1 of 1</span>
+      <button type="button" class="pill-link secondary" data-page="next" disabled>Next</button>
+    </div>
+
+    <aside class="employee-detail" data-employee-detail hidden>
+      <header class="detail-header">
+        <div>
+          <h3 data-detail-name>Employee</h3>
+          <p data-detail-email class="muted"></p>
+        </div>
+        <button type="button" class="pill-link" data-close-detail>Close</button>
+      </header>
+      <dl class="detail-grid">
+        <div>
+          <dt>Department</dt>
+          <dd data-detail-department>—</dd>
+        </div>
+        <div>
+          <dt>Title</dt>
+          <dd data-detail-title>—</dd>
+        </div>
+        <div>
+          <dt>Employment type</dt>
+          <dd data-detail-employment>—</dd>
+        </div>
+        <div>
+          <dt>Status</dt>
+          <dd data-detail-status>—</dd>
+        </div>
+        <div>
+          <dt>Start date</dt>
+          <dd data-detail-start>—</dd>
+        </div>
+        <div>
+          <dt>Emergency contact</dt>
+          <dd data-detail-emergency>—</dd>
+        </div>
+      </dl>
+      <section>
+        <h4>Notes</h4>
+        <p data-detail-notes class="muted">No notes captured.</p>
+      </section>
+    </aside>
+  </section>
 
   <div class="admin-metrics">
     <% metrics.forEach(function(metric) { %>
@@ -441,6 +565,79 @@
       </ul>
     </section>
   </div>
+
+  <div class="employee-modal" data-employee-modal hidden>
+    <div class="employee-modal__backdrop" data-close-modal></div>
+    <div class="employee-modal__content">
+      <header class="employee-modal__header">
+        <h3 data-modal-title>New employee</h3>
+        <button type="button" class="pill-link" data-close-modal>Close</button>
+      </header>
+      <form data-employee-form>
+        <input type="hidden" name="id" data-field="id" />
+        <div class="employee-form-grid">
+          <label>
+            <span>Full name</span>
+            <input type="text" name="name" data-field="name" required />
+          </label>
+          <label>
+            <span>Email</span>
+            <input type="email" name="email" data-field="email" required />
+          </label>
+          <label>
+            <span>Phone</span>
+            <input type="text" name="phone" data-field="phone" />
+          </label>
+          <label>
+            <span>Department</span>
+            <input type="text" name="department" data-field="department" />
+          </label>
+          <label>
+            <span>Title</span>
+            <input type="text" name="title" data-field="title" />
+          </label>
+          <label>
+            <span>Employment type</span>
+            <select name="employmentType" data-field="employmentType">
+              <option value="Full-Time">Full-Time</option>
+              <option value="Part-Time">Part-Time</option>
+              <option value="Contract">Contract</option>
+              <option value="Seasonal">Seasonal</option>
+              <option value="Temporary">Temporary</option>
+              <option value="Intern">Intern</option>
+            </select>
+          </label>
+          <label>
+            <span>Start date</span>
+            <input type="date" name="startDate" data-field="startDate" />
+          </label>
+          <label>
+            <span>Status</span>
+            <select name="status" data-field="status">
+              <option value="active">Active</option>
+              <option value="on-leave">On leave</option>
+              <option value="suspended">Suspended</option>
+              <option value="terminated">Terminated</option>
+            </select>
+          </label>
+          <label>
+            <span>Emergency contact</span>
+            <input type="text" name="emergencyContact" data-field="emergencyContact" />
+          </label>
+          <label class="notes-field">
+            <span>Notes</span>
+            <textarea name="notes" rows="3" data-field="notes"></textarea>
+          </label>
+        </div>
+        <footer class="employee-modal__footer">
+          <button type="button" class="pill-link" data-close-modal>Cancel</button>
+          <button type="submit" class="pill-link primary" data-submit-label>Save employee</button>
+        </footer>
+      </form>
+    </div>
+  </div>
+
+  <div class="employee-toast" data-employee-toast hidden></div>
 </section>
 
 <script defer src="/js/admin.js"></script>

--- a/views/admin/requests.ejs
+++ b/views/admin/requests.ejs
@@ -1,0 +1,104 @@
+<%- include('../partials/head', { pageTitle, hotelName, csrfToken, darkMode }) %>
+<script defer src="/js/admin-requests.js"></script>
+<%- include('../partials/nav') %>
+<%- include('../partials/alerts') %>
+
+<section class="admin admin-requests" data-animate="fade-up">
+  <header class="requests-header">
+    <h1>Employee requests queue</h1>
+    <p>Review PTO, transfer, resignation, and incident submissions from the crew.</p>
+  </header>
+
+  <div class="requests-toolbar">
+    <label class="sr-only" for="requests-search">Search requests</label>
+    <input id="requests-search" type="search" placeholder="Search by employee or type" data-request-search />
+    <div class="requests-filters">
+      <label class="sr-only" for="requests-status">Filter by status</label>
+      <select id="requests-status" data-request-filter="status">
+        <option value="pending">Pending</option>
+        <option value="approved">Approved</option>
+        <option value="denied">Denied</option>
+      </select>
+      <label class="sr-only" for="requests-type">Filter by type</label>
+      <select id="requests-type" data-request-filter="type">
+        <option value="">All types</option>
+        <option value="pto">PTO</option>
+        <option value="workers-comp">Workers comp</option>
+        <option value="transfer">Transfer</option>
+        <option value="resignation">Resignation</option>
+      </select>
+    </div>
+  </div>
+
+  <div class="requests-table-wrapper">
+    <table class="admin-table requests-table">
+      <thead>
+        <tr>
+          <th scope="col">Employee</th>
+          <th scope="col">Type</th>
+          <th scope="col">Submitted</th>
+          <th scope="col">Status</th>
+          <th scope="col">Latest comment</th>
+          <th scope="col">Actions</th>
+        </tr>
+      </thead>
+      <tbody data-request-rows>
+        <tr data-empty>
+          <td colspan="6">Loading requests…</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="request-detail" data-request-detail hidden>
+    <header class="detail-header">
+      <div>
+        <h2 data-detail-title>Request</h2>
+        <p class="muted" data-detail-subtitle></p>
+      </div>
+      <button type="button" class="pill-link" data-close-request>Close</button>
+    </header>
+    <section class="detail-body">
+      <dl class="detail-grid">
+        <div>
+          <dt>Employee</dt>
+          <dd data-detail-employee>—</dd>
+        </div>
+        <div>
+          <dt>Department</dt>
+          <dd data-detail-department>—</dd>
+        </div>
+        <div>
+          <dt>Status</dt>
+          <dd data-detail-status>—</dd>
+        </div>
+        <div>
+          <dt>Submitted</dt>
+          <dd data-detail-created>—</dd>
+        </div>
+        <div>
+          <dt>Payload</dt>
+          <dd data-detail-payload>—</dd>
+        </div>
+      </dl>
+      <form class="request-decision" data-request-decision>
+        <label class="sr-only" for="decision-comment">Decision comment</label>
+        <textarea id="decision-comment" rows="3" placeholder="Add a decision note" data-decision-comment></textarea>
+        <div class="decision-actions">
+          <button type="button" class="pill-link" data-decision="deny">Deny</button>
+          <button type="button" class="pill-link primary" data-decision="approve">Approve</button>
+        </div>
+      </form>
+    </section>
+  </div>
+
+  <div class="employee-toast request-toast" data-request-toast hidden></div>
+
+  <div class="requests-pagination" data-request-pagination>
+    <button type="button" class="pill-link secondary" data-page="prev" disabled>Previous</button>
+    <span data-page-status>Page 1 of 1</span>
+    <button type="button" class="pill-link secondary" data-page="next" disabled>Next</button>
+  </div>
+</section>
+
+<%- include('../partials/footer') %>


### PR DESCRIPTION
## Summary
- deduplicate employee status options for filters, inline edits, and the modal while keeping selections in sync
- refresh bulk/mode dropdowns from live filters and surface skipped counts when importing leadership data

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68edc863d4e483239e569249fa9c2cc4