### PR TITLE
Revamp admin timekeeping console

### DIFF
--- a/public/css/admin-console.css
+++ b/public/css/admin-console.css
@@ -5,9 +5,13 @@
   color: #e2e8f0;
 }
 
+
 .admin-console__header {
-  display: grid;
-  gap: 0.75rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-start;
+  justify-content: space-between;
   margin-bottom: 2.5rem;
 }
 
@@ -16,7 +20,7 @@
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-size: clamp(1.6rem, 3vw, 2.2rem);
-  margin: 0;
+  margin: 0 0 0.25rem;
 }
 
 .admin-console__header .muted {
@@ -27,48 +31,146 @@
   align-self: flex-start;
 }
 
+.btn.btn-ghost {
+  background: transparent;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  color: #e0f2fe;
+}
+
+.btn.btn-ghost:hover {
+  border-color: rgba(125, 211, 252, 0.6);
+  color: #38bdf8;
+}
+
+.btn.btn-compact {
+  padding: 0.35rem 0.8rem;
+  font-size: 0.75rem;
+}
+
+.admin-time__insights {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.2rem;
+  margin-bottom: 2.4rem;
+}
+
+.time-metric-card {
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.9), rgba(30, 64, 175, 0.65));
+  border-radius: 1.4rem;
+  padding: 1.4rem;
+  box-shadow: 0 25px 80px rgba(15, 23, 42, 0.45);
+  display: grid;
+  gap: 0.6rem;
+}
+
+.time-metric-card__label {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #9fb9ff;
+}
+
+.time-metric-card__value {
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+  color: #f8fafc;
+}
+
+.time-metric-card__meta {
+  font-size: 0.85rem;
+  color: #b3c5f0;
+}
+
 .admin-time__layout {
   display: grid;
   gap: 2rem;
-  grid-template-columns: minmax(0, 1fr) 320px;
+  grid-template-columns: minmax(0, 1fr) 360px;
+  align-items: start;
 }
 
 .admin-time__table {
   background: rgba(15, 23, 42, 0.72);
   border-radius: 1.5rem;
-  padding: 1.5rem;
+  padding: 1.8rem;
   box-shadow: 0 30px 80px rgba(15, 23, 42, 0.45);
 }
 
-.admin-time__table header h2 {
-  margin: 0;
+.admin-time__table-header {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.admin-time__table-header h2 {
+  margin: 0 0 0.35rem;
   font-size: 1.25rem;
+}
+
+.admin-time__table-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin: 1.4rem 0 0.6rem;
+}
+
+.chip {
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(15, 23, 42, 0.4);
+  color: #dbeafe;
+  border-radius: 999px;
+  padding: 0.45rem 1rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.chip:hover,
+.chip:focus-visible {
+  border-color: rgba(125, 211, 252, 0.75);
+  color: #38bdf8;
+}
+
+.chip--active {
+  background: rgba(56, 189, 248, 0.16);
+  border-color: rgba(56, 189, 248, 0.6);
+  color: #f8fafc;
 }
 
 .admin-time__filters {
   display: grid;
-  gap: 0.75rem;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  margin: 1.5rem 0;
+  gap: 0.9rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  margin: 1.6rem 0 1.2rem;
 }
 
 .admin-time__filters label {
   display: grid;
-  gap: 0.4rem;
+  gap: 0.45rem;
   font-size: 0.85rem;
   color: #a3b3d5;
 }
 
-.admin-time__filters input {
-  border-radius: 0.8rem;
+.admin-time__filters input,
+.admin-time__filters select {
+  border-radius: 0.9rem;
   padding: 0.65rem 0.9rem;
   border: 1px solid rgba(148, 163, 184, 0.25);
   background: rgba(15, 23, 42, 0.6);
   color: #f8fafc;
 }
 
-.admin-time__filters .btn {
-  margin-top: auto;
+.admin-time__filter-buttons {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.6rem;
+  align-content: end;
 }
 
 .admin-table {
@@ -79,13 +181,150 @@
 
 .admin-table th,
 .admin-table td {
-  padding: 0.75rem 0.9rem;
+  padding: 0.85rem 0.9rem;
   border-bottom: 1px solid rgba(148, 163, 184, 0.15);
   text-align: left;
+  vertical-align: top;
 }
 
 .admin-table tbody tr:hover {
   background: rgba(56, 189, 248, 0.12);
+}
+
+.admin-table tbody tr.is-active {
+  background: rgba(56, 189, 248, 0.18);
+}
+
+.admin-table tbody tr.is-open {
+  border-left: 3px solid rgba(56, 189, 248, 0.6);
+}
+
+.admin-table tbody tr.is-flagged {
+  border-left: 3px solid rgba(248, 250, 252, 0.4);
+}
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.75rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.status-chip--open {
+  background: rgba(56, 189, 248, 0.15);
+  border-color: rgba(56, 189, 248, 0.4);
+  color: #38bdf8;
+}
+
+.status-chip--ok {
+  background: rgba(34, 197, 94, 0.15);
+  border-color: rgba(34, 197, 94, 0.45);
+  color: #4ade80;
+}
+
+.status-chip--alert {
+  background: rgba(248, 113, 113, 0.18);
+  border-color: rgba(248, 113, 113, 0.5);
+  color: #fca5a5;
+}
+
+.status-chip--review {
+  background: rgba(250, 204, 21, 0.22);
+  border-color: rgba(250, 204, 21, 0.45);
+  color: #facc15;
+}
+
+.status-note {
+  font-size: 0.78rem;
+  margin-top: 0.35rem;
+  color: #cbd5f5;
+}
+
+.admin-time__detail {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.time-detail-card {
+  background: rgba(8, 47, 73, 0.55);
+  border-radius: 1.4rem;
+  padding: 1.5rem;
+  box-shadow: 0 25px 60px rgba(15, 23, 42, 0.4);
+}
+
+.time-detail-card form {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.time-detail-card input,
+.time-detail-card textarea {
+  width: 100%;
+  border-radius: 0.9rem;
+  padding: 0.7rem 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.6);
+  color: #f8fafc;
+}
+
+.time-detail-card textarea {
+  min-height: 110px;
+  resize: vertical;
+}
+
+.time-detail-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.time-side-panels {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.time-panel {
+  background: rgba(8, 47, 73, 0.45);
+  border-radius: 1.4rem;
+  padding: 1.3rem;
+  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.35);
+}
+
+.time-panel header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  margin-bottom: 0.8rem;
+}
+
+.time-panel h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.time-panel__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.time-panel__list li {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.time-panel__list .muted {
+  color: #9db3ce;
 }
 
 .admin-requests {
@@ -144,38 +383,16 @@
   color: #f8fafc;
 }
 
-.admin-time__detail {
-  background: rgba(8, 47, 73, 0.55);
-  border-radius: 1.4rem;
-  padding: 1.5rem;
-  box-shadow: 0 25px 60px rgba(15, 23, 42, 0.4);
-}
-
-.admin-time__detail h2 {
-  margin-top: 0;
-}
-
-.admin-time__detail form {
-  display: grid;
-  gap: 0.9rem;
-}
-
-.admin-time__detail input,
-.admin-time__detail textarea {
-  width: 100%;
-  border-radius: 0.9rem;
-  padding: 0.7rem 0.85rem;
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  background: rgba(15, 23, 42, 0.6);
-  color: #f8fafc;
-}
-
 @media (max-width: 980px) {
   .admin-time__layout {
     grid-template-columns: 1fr;
   }
 
-  .admin-time__detail {
-    order: -1;
+  .admin-time__insights {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  }
+
+  .time-detail-actions {
+    justify-content: flex-start;
   }
 }

--- a/public/js/admin-time.js
+++ b/public/js/admin-time.js
@@ -2,23 +2,45 @@
   const csrfToken = window.AdminTime?.csrfToken || document.querySelector('meta[name="csrf-token"]').content;
   const tableBody = document.querySelector('#time-entries-table tbody');
   const filterEmployee = document.getElementById('time-filter-employee');
+  const filterSearch = document.getElementById('time-filter-search');
   const filterStart = document.getElementById('time-filter-start');
   const filterEnd = document.getElementById('time-filter-end');
+  const filterStatus = document.getElementById('time-filter-status');
+  const filterLocation = document.getElementById('time-filter-location');
   const filterApply = document.getElementById('time-filter-apply');
+  const filterClear = document.getElementById('time-filter-clear');
+  const rangeButtons = document.querySelectorAll('#time-range-chips .chip');
+  const refreshButton = document.getElementById('time-refresh');
+  const exportButton = document.getElementById('time-export');
   const detailPanel = document.getElementById('time-detail');
   const adjustForm = document.getElementById('time-adjust-form');
   const entryIdInput = document.getElementById('time-entry-id');
   const clockInInput = document.getElementById('time-clock-in');
   const clockOutInput = document.getElementById('time-clock-out');
+  const roleInput = document.getElementById('time-role');
   const departmentInput = document.getElementById('time-department');
   const locationInput = document.getElementById('time-location');
   const notesInput = document.getElementById('time-notes');
+  const clockoutNowButton = document.getElementById('time-clockout-now');
+  const activeList = document.getElementById('time-active-list');
+  const flaggedList = document.getElementById('time-flagged-list');
+  const coverageList = document.getElementById('time-coverage-list');
+  const trendList = document.getElementById('time-trend-list');
+  const totalHoursEl = document.getElementById('time-total-hours');
+  const totalHoursMeta = document.getElementById('time-total-hours-meta');
+  const averageDurationEl = document.getElementById('time-average-duration');
+  const longestEl = document.getElementById('time-longest');
+  const activeCountEl = document.getElementById('time-active-count');
+  const reviewCountEl = document.getElementById('time-review-count');
+  const activeSubEl = document.getElementById('time-active-sub');
   let entries = [];
+  let currentView = [];
   let activeEntry = null;
 
   function toLocalInput(value) {
     if (!value) return '';
     const date = new Date(value);
+    if (Number.isNaN(date.valueOf())) return '';
     const offset = date.getTimezoneOffset();
     const local = new Date(date.getTime() - offset * 60000);
     return local.toISOString().slice(0, 16);
@@ -28,86 +50,503 @@
     if (!minutes && minutes !== 0) return '—';
     const hrs = Math.floor(minutes / 60);
     const mins = minutes % 60;
-    if (!hrs) return `${mins}m`;
-    if (!mins) return `${hrs}h`;
-    return `${hrs}h ${mins}m`;
+    if (hrs && mins) return `${hrs}h ${mins}m`;
+    if (hrs) return `${hrs}h`;
+    return `${mins}m`;
   }
 
-  function renderEntries(list) {
+  function calculateOpenMinutes(entry) {
+    if (!entry.clockInAt || entry.clockOutAt) return null;
+    const clockInDate = new Date(entry.clockInAt);
+    if (Number.isNaN(clockInDate.valueOf())) return null;
+    return Math.max(0, Math.round((Date.now() - clockInDate.getTime()) / 60000));
+  }
+
+  function getEntryStatus(entry) {
+    const open = !entry.clockOutAt;
+    const durationMinutes = entry.durationMinutes ?? calculateOpenMinutes(entry) ?? 0;
+    const overtime = entry.durationMinutes && entry.durationMinutes >= 10 * 60;
+    const extendedOpen = open && durationMinutes >= 8 * 60;
+    const needsReview = overtime || extendedOpen || (entry.clockOutAt && !entry.durationMinutes);
+    if (open) return 'open';
+    if (overtime) return 'overtime';
+    if (needsReview) return 'needs-review';
+    return 'completed';
+  }
+
+  function enrichEntry(entry) {
+    if (!entry) return null;
+    const existing = entries.find((item) => item.id === entry.id);
+    const mergedEmployee = entry.employee || existing?.employee || null;
+    const displayMinutes = entry.durationMinutes ?? calculateOpenMinutes(entry);
+    const clockInLabel = entry.clockInAt ? new Date(entry.clockInAt).toLocaleString() : '—';
+    const clockOutLabel = entry.clockOutAt ? new Date(entry.clockOutAt).toLocaleString() : '—';
+    return {
+      ...existing,
+      ...entry,
+      employee: mergedEmployee,
+      displayMinutes,
+      clockInLabel,
+      clockOutLabel,
+      durationLabel: displayMinutes ? formatDuration(displayMinutes) : (entry.clockOutAt ? 'Needs review' : 'Open')
+    };
+  }
+
+  function populateLocationFilter(list) {
+    if (!filterLocation) return;
+    const currentValue = filterLocation.value;
+    const options = ['<option value="">All locations</option>'];
+    const seen = new Set();
+    list.forEach((entry) => {
+      if (!entry.location) return;
+      const key = entry.location.toLowerCase();
+      if (seen.has(key)) return;
+      seen.add(key);
+      options.push(`<option value="${key}">${entry.location}</option>`);
+    });
+    filterLocation.innerHTML = options.join('');
+    if (currentValue && seen.has(currentValue)) {
+      filterLocation.value = currentValue;
+    }
+  }
+
+  function applyClientFilters(list) {
+    const status = filterStatus?.value || '';
+    const location = filterLocation?.value || '';
+    const search = filterSearch?.value.trim().toLowerCase() || '';
+    return list.filter((entry) => {
+      const entryStatus = getEntryStatus(entry);
+      if (status) {
+        if (status === 'needs-review') {
+          if (!['needs-review', 'overtime'].includes(entryStatus)) return false;
+        } else if (entryStatus !== status) {
+          return false;
+        }
+      }
+      if (location) {
+        if ((entry.location || '').toLowerCase() !== location) return false;
+      }
+      if (search) {
+        const haystack = [
+          entry.employeeId,
+          entry.employee?.name,
+          entry.employee?.email,
+          entry.department,
+          entry.role
+        ]
+          .map((value) => (value || '').toString().toLowerCase())
+          .join(' ');
+        if (!haystack.includes(search)) return false;
+      }
+      return true;
+    });
+  }
+
+  function renderTable(list) {
     if (!tableBody) return;
     tableBody.innerHTML = '';
-    if (!list || !list.length) {
+    if (!list.length) {
       const row = document.createElement('tr');
-      row.innerHTML = '<td colspan="7" class="muted">No entries match the filter.</td>';
+      row.innerHTML = '<td colspan="8" class="muted">No entries match the current filters.</td>';
       tableBody.appendChild(row);
       return;
     }
+
     list.forEach((entry) => {
       const row = document.createElement('tr');
       row.dataset.entryId = entry.id;
       row.dataset.entry = JSON.stringify(entry);
-      const clockIn = entry.clockInAt ? new Date(entry.clockInAt).toLocaleString() : '—';
-      const clockOut = entry.clockOutAt ? new Date(entry.clockOutAt).toLocaleString() : '—';
-      const durationLabel = entry.clockOutAt ? formatDuration(entry.durationMinutes) : 'Open';
+      const status = getEntryStatus(entry);
+      row.dataset.status = status;
+      row.dataset.location = (entry.location || '').toLowerCase();
+      row.dataset.employeeName = (entry.employee?.name || '').toLowerCase();
+      row.dataset.employeeEmail = (entry.employee?.email || '').toLowerCase();
+      row.dataset.employeeId = entry.employeeId.toLowerCase();
+
+      const statusLabelMap = {
+        open: { label: 'Open', className: 'status-chip--open' },
+        overtime: { label: 'Overtime', className: 'status-chip--alert' },
+        'needs-review': { label: 'Needs review', className: 'status-chip--review' },
+        completed: { label: 'Complete', className: 'status-chip--ok' }
+      };
+      const statusMeta = statusLabelMap[status] || statusLabelMap.completed;
+      row.classList.toggle('is-open', status === 'open');
+      row.classList.toggle('is-flagged', ['overtime', 'needs-review'].includes(status));
+
       row.innerHTML = `
-        <td><strong>${entry.employee?.name || entry.employeeId}</strong><br /><span class="muted">${entry.employee?.email || entry.employeeId}</span></td>
-        <td>${clockIn}</td>
-        <td>${clockOut}</td>
-        <td>${durationLabel}</td>
+        <td>
+          <strong>${entry.employee?.name || entry.employeeId}</strong>
+          <div class="muted">ID: ${entry.employeeId}</div>
+          ${entry.employee?.email ? `<div class="muted">${entry.employee.email}</div>` : ''}
+        </td>
+        <td>
+          <span>${entry.role || entry.department || entry.employee?.department || '—'}</span>
+          ${entry.department || entry.employee?.department ? `<div class="muted">Dept: ${entry.department || entry.employee?.department}</div>` : ''}
+        </td>
+        <td>${entry.clockInLabel || '—'}</td>
+        <td>${entry.clockOutLabel || '—'}</td>
+        <td>${entry.durationLabel || '—'}</td>
         <td>${entry.location || '—'}</td>
-        <td>${entry.notes || '—'}</td>
+        <td>
+          <span class="status-chip ${statusMeta.className}">${statusMeta.label}</span>
+          ${entry.notes ? `<div class="muted status-note">${entry.notes}</div>` : ''}
+        </td>
         <td><button type="button" class="btn btn-outline time-adjust">Adjust</button></td>
       `;
       tableBody.appendChild(row);
     });
   }
 
+  function updateInsights(list) {
+    const totalMinutes = list.reduce((sum, entry) => sum + (entry.durationMinutes || 0), 0);
+    const completedCount = list.filter((entry) => entry.durationMinutes).length;
+    if (totalHoursEl) {
+      totalHoursEl.textContent = `${(totalMinutes / 60).toFixed(1)}h`;
+    }
+    if (totalHoursMeta) {
+      totalHoursMeta.innerHTML = `Across <strong>${completedCount}</strong> completed shifts`;
+    }
+
+    const averageHours = completedCount ? totalMinutes / 60 / completedCount : 0;
+    if (averageDurationEl) {
+      averageDurationEl.textContent = `${averageHours.toFixed(2)}h`;
+    }
+
+    const openEntries = list.filter((entry) => !entry.clockOutAt);
+    if (activeCountEl) {
+      activeCountEl.textContent = openEntries.length;
+    }
+    if (activeSubEl) {
+      activeSubEl.textContent = openEntries.length ? 'Live coverage overview' : 'All team members are clocked out';
+    }
+
+    const flagged = list.filter((entry) => ['overtime', 'needs-review'].includes(getEntryStatus(entry)));
+    if (reviewCountEl) {
+      reviewCountEl.textContent = flagged.length;
+    }
+
+    const longest = list.reduce((acc, entry) => {
+      const duration = entry.durationMinutes || 0;
+      if (duration > (acc?.durationMinutes || 0)) return entry;
+      return acc;
+    }, null);
+    if (longestEl) {
+      if (longest) {
+        longestEl.textContent = `${longest.employee?.name || longest.employeeId} • ${formatDuration(longest.durationMinutes)}`;
+      } else {
+        longestEl.textContent = '—';
+      }
+    }
+
+    function renderList(target, items, emptyLabel, builder) {
+      if (!target) return;
+      target.innerHTML = '';
+      if (!items.length) {
+        const emptyItem = document.createElement('li');
+        emptyItem.className = 'muted';
+        emptyItem.textContent = emptyLabel;
+        target.appendChild(emptyItem);
+        return;
+      }
+      items.forEach((item) => {
+        const element = document.createElement('li');
+        element.innerHTML = builder(item);
+        if (item.id) {
+          element.dataset.entryId = item.id;
+        }
+        target.appendChild(element);
+      });
+    }
+
+    renderList(
+      activeList,
+      openEntries.slice(0, 6),
+      'No active shifts right now.',
+      (entry) => `
+        <div>
+          <strong>${entry.employee?.name || entry.employeeId}</strong>
+          <div class="muted">Clocked in ${entry.clockInLabel}</div>
+        </div>
+        <button type="button" class="btn btn-ghost btn-compact" data-action="clockout" data-entry-id="${entry.id}">Clock out</button>
+      `
+    );
+
+    renderList(
+      flaggedList,
+      flagged.slice(0, 8),
+      'All clear. No anomalies detected.',
+      (entry) => `
+        <div>
+          <strong>${entry.employee?.name || entry.employeeId}</strong>
+          <div class="muted">${entry.durationLabel} • ${entry.clockInLabel}</div>
+        </div>
+      `
+    );
+
+    const coverageMap = list.reduce((map, entry) => {
+      const label = entry.department || entry.employee?.department || 'Unassigned';
+      const key = label.toLowerCase();
+      const bucket = map.get(key) || { label, minutes: 0, count: 0 };
+      const effectiveMinutes = entry.durationMinutes ?? calculateOpenMinutes(entry) ?? 0;
+      bucket.minutes += effectiveMinutes;
+      bucket.count += 1;
+      map.set(key, bucket);
+      return map;
+    }, new Map());
+    const coverage = Array.from(coverageMap.values()).sort((a, b) => b.minutes - a.minutes).slice(0, 6);
+    renderList(
+      coverageList,
+      coverage,
+      'No recent coverage data.',
+      (row) => `
+        <div>
+          <strong>${row.label}</strong>
+          <div class="muted">${Math.round(row.minutes / 60)}h • ${row.count} shifts</div>
+        </div>
+      `
+    );
+
+    const dailyBuckets = list.reduce((map, entry) => {
+      if (!entry.clockInAt) return map;
+      const key = entry.clockInAt.slice(0, 10);
+      const bucket = map.get(key) || { date: key, minutes: 0, count: 0 };
+      const effectiveMinutes = entry.durationMinutes ?? calculateOpenMinutes(entry) ?? 0;
+      bucket.minutes += effectiveMinutes;
+      bucket.count += 1;
+      map.set(key, bucket);
+      return map;
+    }, new Map());
+    const trend = Array.from(dailyBuckets.values())
+      .sort((a, b) => new Date(b.date) - new Date(a.date))
+      .slice(0, 7);
+    renderList(
+      trendList,
+      trend,
+      'No recent daily totals.',
+      (row) => `
+        <div>
+          <strong>${new Date(row.date).toLocaleDateString()}</strong>
+          <div class="muted">${Math.round(row.minutes / 60)}h • ${row.count} shifts</div>
+        </div>
+      `
+    );
+  }
+
+  function refreshView() {
+    currentView = applyClientFilters(entries);
+    renderTable(currentView);
+    updateInsights(currentView);
+  }
+
   function parseInitialEntries() {
     if (!tableBody) return;
-    entries = Array.from(tableBody.querySelectorAll('tr[data-entry]')).map((row) => {
-      try {
-        return JSON.parse(row.dataset.entry);
-      } catch (error) {
-        return null;
-      }
-    }).filter(Boolean);
+    entries = Array.from(tableBody.querySelectorAll('tr[data-entry]'))
+      .map((row) => {
+        try {
+          return JSON.parse(row.dataset.entry);
+        } catch (error) {
+          return null;
+        }
+      })
+      .filter(Boolean)
+      .map(enrichEntry)
+      .filter(Boolean);
+    populateLocationFilter(entries);
+    refreshView();
   }
 
   function showDetail(entry) {
     if (!detailPanel) return;
     activeEntry = entry;
     detailPanel.hidden = false;
+    detailPanel.classList.add('is-visible');
     entryIdInput.value = entry.id;
     clockInInput.value = toLocalInput(entry.clockInAt);
     clockOutInput.value = toLocalInput(entry.clockOutAt);
-    departmentInput.value = entry.department || '';
+    roleInput.value = entry.role || '';
+    departmentInput.value = entry.department || entry.employee?.department || '';
     locationInput.value = entry.location || '';
     notesInput.value = entry.notes || '';
+    if (clockoutNowButton) {
+      clockoutNowButton.dataset.entryId = entry.id;
+      clockoutNowButton.disabled = Boolean(entry.clockOutAt);
+    }
+    Array.from(tableBody?.querySelectorAll('tr') || []).forEach((row) => {
+      row.classList.toggle('is-active', row.dataset.entryId === entry.id);
+    });
   }
 
   async function fetchEntries() {
     const params = new URLSearchParams();
-    if (filterEmployee.value.trim()) {
+    if (filterEmployee?.value.trim()) {
       params.set('employeeId', filterEmployee.value.trim());
     }
-    if (filterStart.value) {
+    if (filterStart?.value) {
       params.set('start', filterStart.value);
     }
-    if (filterEnd.value) {
+    if (filterEnd?.value) {
       params.set('end', filterEnd.value);
     }
-    const url = `/api/admin/time-entries?${params.toString()}`;
+    const query = params.toString();
+    const url = query ? `/api/admin/time-entries?${query}` : '/api/admin/time-entries';
     try {
       const response = await fetch(url, { headers: { Accept: 'application/json' } });
       if (!response.ok) {
         throw new Error('Unable to load time entries');
       }
       const data = await response.json();
-      entries = data.entries || [];
-      renderEntries(entries);
+      entries = (data.entries || []).map(enrichEntry).filter(Boolean);
+      populateLocationFilter(entries);
+      refreshView();
     } catch (error) {
       alert(error.message || 'Failed to retrieve entries');
     }
+  }
+
+  async function clockOutEntry(entryId, button) {
+    if (!entryId) return;
+    if (button) {
+      button.disabled = true;
+      button.textContent = 'Clocking…';
+    }
+    try {
+      const response = await fetch(`/api/admin/time-entries/${entryId}/adjust`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'CSRF-Token': csrfToken
+        },
+        body: JSON.stringify({ clockOutAt: new Date().toISOString() })
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.error || 'Unable to clock out entry');
+      }
+      const updated = enrichEntry(data.entry);
+      entries = entries.map((entry) => (entry.id === updated.id ? updated : entry));
+      if (activeEntry && activeEntry.id === updated.id) {
+        activeEntry = updated;
+        showDetail(updated);
+      }
+      refreshView();
+      alert('Shift clocked out.');
+    } catch (error) {
+      alert(error.message || 'Failed to clock out entry');
+    } finally {
+      if (button) {
+        button.disabled = false;
+        button.textContent = 'Clock out';
+      }
+    }
+  }
+
+  function exportCsv() {
+    if (!currentView.length) {
+      alert('No entries to export.');
+      return;
+    }
+    const header = [
+      'Employee Name',
+      'Employee ID',
+      'Email',
+      'Clock In',
+      'Clock Out',
+      'Duration (minutes)',
+      'Location',
+      'Department',
+      'Role',
+      'Notes',
+      'Status'
+    ];
+    const rows = currentView.map((entry) => {
+      const status = getEntryStatus(entry);
+      return [
+        entry.employee?.name || '',
+        entry.employeeId,
+        entry.employee?.email || '',
+        entry.clockInAt || '',
+        entry.clockOutAt || '',
+        entry.durationMinutes ?? calculateOpenMinutes(entry) ?? '',
+        entry.location || '',
+        entry.department || entry.employee?.department || '',
+        entry.role || '',
+        (entry.notes || '').replace(/\r?\n/g, ' '),
+        status
+      ];
+    });
+    const csv = [header, ...rows]
+      .map((line) => line.map((field) => {
+        const value = field == null ? '' : String(field);
+        if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+          return `"${value.replace(/"/g, '""')}"`;
+        }
+        return value;
+      }).join(','))
+      .join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `time-entries-${new Date().toISOString().slice(0, 10)}.csv`;
+    link.click();
+    URL.revokeObjectURL(url);
+  }
+
+  function clearFilters() {
+    if (filterEmployee) filterEmployee.value = '';
+    if (filterSearch) filterSearch.value = '';
+    if (filterStatus) filterStatus.value = '';
+    if (filterLocation) filterLocation.value = '';
+    if (filterStart) filterStart.value = '';
+    if (filterEnd) filterEnd.value = '';
+    rangeButtons.forEach((button) => button.classList.remove('chip--active'));
+    const defaultChip = document.querySelector('#time-range-chips .chip[data-range="7"]');
+    if (defaultChip) {
+      defaultChip.classList.add('chip--active');
+    }
+    refreshView();
+  }
+
+  function setDateRange(days) {
+    if (!filterStart || !filterEnd) return;
+    const now = new Date();
+    const end = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const start = new Date(end);
+    start.setDate(end.getDate() - (Number(days) - 1));
+    const toInputDate = (date) => date.toISOString().slice(0, 10);
+    filterStart.value = toInputDate(start);
+    filterEnd.value = toInputDate(end);
+  }
+
+  function handleRangeClick(event) {
+    const button = event.target.closest('.chip');
+    if (!button) return;
+    const range = button.dataset.range;
+    rangeButtons.forEach((chip) => chip.classList.toggle('chip--active', chip === button));
+    if (range) {
+      setDateRange(range);
+      fetchEntries();
+    }
+  }
+
+  function handleTableClick(event) {
+    const adjustButton = event.target.closest('.time-adjust');
+    if (!adjustButton) return;
+    const row = adjustButton.closest('tr');
+    if (!row) return;
+    try {
+      const entry = JSON.parse(row.dataset.entry);
+      showDetail(entry);
+    } catch (error) {
+      console.error('Failed to parse entry', error);
+    }
+  }
+
+  function handleActiveListClick(event) {
+    const button = event.target.closest('[data-action="clockout"]');
+    if (!button) return;
+    const entryId = button.dataset.entryId;
+    clockOutEntry(entryId, button);
   }
 
   async function submitAdjustment(event) {
@@ -119,6 +558,7 @@
     const payload = {
       clockInAt: clockInInput.value ? new Date(clockInInput.value).toISOString() : undefined,
       clockOutAt: clockOutInput.value ? new Date(clockOutInput.value).toISOString() : '',
+      role: roleInput.value,
       department: departmentInput.value,
       location: locationInput.value,
       notes: notesInput.value
@@ -136,36 +576,35 @@
       if (!response.ok) {
         throw new Error(data.error || 'Unable to adjust time entry');
       }
+      const updated = enrichEntry(data.entry);
+      entries = entries.map((entry) => (entry.id === updated.id ? updated : entry));
+      activeEntry = updated;
+      refreshView();
+      showDetail(updated);
       alert('Time entry updated.');
-      activeEntry = data.entry;
-      const index = entries.findIndex((entry) => entry.id === data.entry.id);
-      if (index >= 0) {
-        entries[index] = data.entry;
-      } else {
-        entries.unshift(data.entry);
-      }
-      renderEntries(entries);
-      showDetail(data.entry);
     } catch (error) {
       alert(error.message || 'Failed to submit adjustment');
     }
   }
 
   parseInitialEntries();
+  if (detailPanel) {
+    detailPanel.hidden = true;
+  }
 
-  tableBody?.addEventListener('click', (event) => {
-    const button = event.target.closest('.time-adjust');
-    if (!button) return;
-    const row = button.closest('tr');
-    if (!row) return;
-    try {
-      const entry = JSON.parse(row.dataset.entry);
-      showDetail(entry);
-    } catch (error) {
-      console.error('Failed to parse entry', error);
-    }
-  });
-
+  tableBody?.addEventListener('click', handleTableClick);
+  activeList?.addEventListener('click', handleActiveListClick);
   filterApply?.addEventListener('click', fetchEntries);
+  refreshButton?.addEventListener('click', fetchEntries);
+  exportButton?.addEventListener('click', exportCsv);
+  filterClear?.addEventListener('click', clearFilters);
+  filterSearch?.addEventListener('input', refreshView);
+  filterStatus?.addEventListener('change', refreshView);
+  filterLocation?.addEventListener('change', refreshView);
+  rangeButtons.forEach((button) => button.addEventListener('click', handleRangeClick));
   adjustForm?.addEventListener('submit', submitAdjustment);
+  clockoutNowButton?.addEventListener('click', () => {
+    if (!activeEntry || activeEntry.clockOutAt) return;
+    clockOutEntry(activeEntry.id, clockoutNowButton);
+  });
 })();

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -237,24 +237,118 @@ router.get('/admin', ensureAdmin, (req, res) => {
 
 router.get('/admin/time', ensureAdmin, (req, res) => {
   const start = new Date(Date.now() - 7 * DAY_MS).toISOString();
-  const entries = listEntries({ start }).slice(0, 60).map((entry) => {
+  const rawEntries = listEntries({ start }).slice(0, 160);
+  const now = Date.now();
+  const entries = rawEntries.map((entry) => {
     const clockIn = entry.clockInAt ? new Date(entry.clockInAt) : null;
     const clockOut = entry.clockOutAt ? new Date(entry.clockOutAt) : null;
-    const durationLabel = entry.durationMinutes
-      ? `${Math.floor(entry.durationMinutes / 60)}h ${entry.durationMinutes % 60}m`
+    const employee = getUserById(entry.employeeId);
+    const baseMinutes = entry.durationMinutes ?? null;
+    const openDurationMinutes = !entry.clockOutAt && clockIn
+      ? Math.max(0, Math.round((now - clockIn.getTime()) / 60000))
+      : null;
+    const displayMinutes = baseMinutes ?? openDurationMinutes;
+    const durationLabel = displayMinutes
+      ? `${Math.floor(displayMinutes / 60)}h ${displayMinutes % 60}m`
       : entry.clockOutAt
         ? 'Needs review'
         : 'Open';
     return {
       ...entry,
+      employee: employee
+        ? {
+            id: employee.id,
+            name: employee.name,
+            email: employee.email,
+            department: employee.department || null
+          }
+        : null,
       clockInLabel: clockIn ? clockIn.toLocaleString() : '—',
       clockOutLabel: clockOut ? clockOut.toLocaleString() : '—',
+      displayMinutes,
       durationLabel
     };
   });
+
+  const totals = entries.reduce(
+    (acc, entry) => {
+      if (entry.durationMinutes) {
+        acc.completedMinutes += entry.durationMinutes;
+        acc.completedCount += 1;
+      }
+      if (!entry.clockOutAt) {
+        acc.open.push(entry);
+      }
+      const effectiveMinutes = entry.durationMinutes
+        ?? (entry.displayMinutes ?? 0);
+      if (effectiveMinutes > acc.maxMinutes) {
+        acc.maxMinutes = effectiveMinutes;
+        acc.longest = entry;
+      }
+      const departmentKey = (entry.department || entry.employee?.department || 'Unassigned').toLowerCase();
+      const currentDepartment = acc.departments.get(departmentKey) || {
+        label: entry.department || entry.employee?.department || 'Unassigned',
+        minutes: 0,
+        count: 0
+      };
+      currentDepartment.minutes += effectiveMinutes;
+      currentDepartment.count += 1;
+      acc.departments.set(departmentKey, currentDepartment);
+
+      if (entry.clockInAt) {
+        const dayKey = entry.clockInAt.slice(0, 10);
+        const existingDay = acc.daily.get(dayKey) || {
+          date: dayKey,
+          minutes: 0,
+          count: 0
+        };
+        existingDay.minutes += effectiveMinutes;
+        existingDay.count += 1;
+        acc.daily.set(dayKey, existingDay);
+      }
+
+      const longShift = entry.durationMinutes && entry.durationMinutes >= 10 * 60;
+      const extendedOpen = !entry.clockOutAt && entry.displayMinutes && entry.displayMinutes >= 8 * 60;
+      if (longShift || extendedOpen) {
+        acc.flagged.push(entry);
+      }
+
+      return acc;
+    },
+    {
+      completedMinutes: 0,
+      completedCount: 0,
+      open: [],
+      maxMinutes: 0,
+      longest: null,
+      departments: new Map(),
+      daily: new Map(),
+      flagged: []
+    }
+  );
+
+  const coverage = Array.from(totals.departments.values()).sort((a, b) => b.minutes - a.minutes).slice(0, 6);
+  const dailySummaries = Array.from(totals.daily.values())
+    .sort((a, b) => new Date(b.date) - new Date(a.date))
+    .slice(0, 7);
+
+  const stats = {
+    totalHours: totals.completedMinutes / 60,
+    averageHours: totals.completedCount ? totals.completedMinutes / 60 / totals.completedCount : 0,
+    openCount: totals.open.length,
+    flaggedCount: totals.flagged.length,
+    completedCount: totals.completedCount,
+    coverage,
+    dailySummaries,
+    longest: totals.longest,
+    flagged: totals.flagged.slice(0, 8),
+    openEntries: totals.open
+  };
+
   res.render('admin/time', {
     pageTitle: 'Timekeeping Console',
-    entries
+    entries,
+    stats
   });
 });
 

--- a/views/admin/time.ejs
+++ b/views/admin/time.ejs
@@ -4,21 +4,66 @@
 
 <section class="admin-console" data-animate="fade-up">
   <header class="admin-console__header">
-    <h1>Timekeeping Console</h1>
-    <p class="muted">Monitor crew punches, identify anomalies, and adjust entries for compliance.</p>
+    <div>
+      <h1>Timekeeping Console</h1>
+      <p class="muted">Monitor crew punches, identify anomalies, and adjust entries for compliance.</p>
+    </div>
     <a href="/admin" class="btn btn-outline">Back to control deck</a>
   </header>
 
+  <% const metrics = stats || {}; %>
+
+  <div class="admin-time__insights">
+    <article class="time-metric-card">
+      <span class="time-metric-card__label">Total hours logged</span>
+      <span class="time-metric-card__value" id="time-total-hours"><%= typeof metrics.totalHours === 'number' ? metrics.totalHours.toFixed(1) : '0.0' %>h</span>
+      <span class="time-metric-card__meta" id="time-total-hours-meta">Across <strong><%= metrics.completedCount || 0 %></strong> completed shifts</span>
+    </article>
+    <article class="time-metric-card">
+      <span class="time-metric-card__label">Average shift length</span>
+      <span class="time-metric-card__value" id="time-average-duration"><%= typeof metrics.averageHours === 'number' ? metrics.averageHours.toFixed(2) : '0.00' %>h</span>
+      <span class="time-metric-card__meta">Longest shift: <strong id="time-longest"><% if (metrics.longest) { %><%= metrics.longest.employee?.name || metrics.longest.employeeId %> • <%= metrics.longest.durationLabel %><% } else { %>—<% } %></strong></span>
+    </article>
+    <article class="time-metric-card">
+      <span class="time-metric-card__label">Active right now</span>
+      <span class="time-metric-card__value" id="time-active-count"><%= metrics.openCount || 0 %></span>
+      <span class="time-metric-card__meta">Keep tabs on in-progress shifts and breaks</span>
+    </article>
+    <article class="time-metric-card">
+      <span class="time-metric-card__label">Attention required</span>
+      <span class="time-metric-card__value" id="time-review-count"><%= metrics.flaggedCount || 0 %></span>
+      <span class="time-metric-card__meta">Flagged for overtime, long opens, or missing punches</span>
+    </article>
+  </div>
+
   <div class="admin-time__layout">
     <section class="admin-time__table">
-      <header>
-        <h2>Recent entries</h2>
-        <p class="muted">Showing the past 7 days. Use the filters below to narrow by crew member or date range.</p>
+      <header class="admin-time__table-header">
+        <div>
+          <h2>Recent entries</h2>
+          <p class="muted">Showing the past 7 days. Use filters or quick ranges to focus on specific teams and timeframes.</p>
+        </div>
+        <div class="admin-time__table-actions">
+          <button class="btn btn-ghost" id="time-refresh" type="button">Refresh</button>
+          <button class="btn btn-outline" id="time-export" type="button">Export CSV</button>
+        </div>
       </header>
+
+      <div class="chip-group" id="time-range-chips" role="group" aria-label="Quick ranges">
+        <button class="chip" data-range="1" type="button">Today</button>
+        <button class="chip chip--active" data-range="7" type="button">Last 7 days</button>
+        <button class="chip" data-range="14" type="button">Last 14 days</button>
+        <button class="chip" data-range="30" type="button">Last 30 days</button>
+      </div>
+
       <div class="admin-time__filters">
         <label>
           <span>Employee ID</span>
-          <input type="text" id="time-filter-employee" placeholder="Search by id" />
+          <input type="text" id="time-filter-employee" placeholder="Exact match (server filter)" />
+        </label>
+        <label>
+          <span>Search roster</span>
+          <input type="text" id="time-filter-search" placeholder="Name, email, or id" />
         </label>
         <label>
           <span>Start</span>
@@ -28,58 +73,214 @@
           <span>End</span>
           <input type="date" id="time-filter-end" />
         </label>
-        <button class="btn" id="time-filter-apply" type="button">Apply</button>
+        <label>
+          <span>Status</span>
+          <select id="time-filter-status">
+            <option value="">All statuses</option>
+            <option value="open">Open</option>
+            <option value="completed">Completed</option>
+            <option value="overtime">Overtime</option>
+            <option value="needs-review">Needs review</option>
+          </select>
+        </label>
+        <label>
+          <span>Location</span>
+          <select id="time-filter-location">
+            <option value="">All locations</option>
+            <% if (entries && entries.length) { %>
+              <% const seenLocations = new Set(); %>
+              <% entries.forEach(function(entry) { %>
+                <% if (entry.location && !seenLocations.has(entry.location.toLowerCase())) { %>
+                  <% seenLocations.add(entry.location.toLowerCase()); %>
+                  <option value="<%= entry.location.toLowerCase() %>"><%= entry.location %></option>
+                <% } %>
+              <% }) %>
+            <% } %>
+          </select>
+        </label>
+        <div class="admin-time__filter-buttons">
+          <button class="btn" id="time-filter-apply" type="button">Apply</button>
+          <button class="btn btn-ghost" id="time-filter-clear" type="button">Clear</button>
+        </div>
       </div>
+
       <table class="admin-table" id="time-entries-table">
         <thead>
           <tr>
             <th>Employee</th>
+            <th>Role / Dept</th>
             <th>Clock In</th>
             <th>Clock Out</th>
             <th>Duration</th>
             <th>Location</th>
-            <th>Notes</th>
+            <th>Status</th>
             <th></th>
           </tr>
         </thead>
         <tbody>
           <% if (entries && entries.length) { %>
             <% entries.forEach(function(entry) { %>
-              <tr data-entry-id="<%= entry.id %>" data-entry='<%- JSON.stringify(entry) %>'>
-                <td><strong><%= entry.employeeId %></strong></td>
+              <% const openShift = !entry.clockOutAt; %>
+              <% const overtimeShift = entry.durationMinutes && entry.durationMinutes >= (10 * 60); %>
+              <% const extendedOpen = !entry.clockOutAt && entry.displayMinutes && entry.displayMinutes >= (8 * 60); %>
+              <% const needsReview = overtimeShift || extendedOpen || (entry.clockOutAt && !entry.durationMinutes); %>
+              <% const status = openShift ? 'open' : (overtimeShift ? 'overtime' : (needsReview ? 'needs-review' : 'completed')); %>
+              <% const statusLabel = openShift ? 'Open' : (overtimeShift ? 'Overtime' : (needsReview ? 'Needs review' : 'Complete')); %>
+              <% const statusClass = openShift ? 'status-chip--open' : (overtimeShift ? 'status-chip--alert' : (needsReview ? 'status-chip--review' : 'status-chip--ok')); %>
+              <tr
+                data-entry-id="<%= entry.id %>"
+                data-entry='<%- JSON.stringify(entry) %>'
+                data-status="<%= status %>"
+                data-location="<%= (entry.location || '').toLowerCase() %>"
+                data-employee-name="<%= (entry.employee?.name || '').toLowerCase() %>"
+                data-employee-email="<%= (entry.employee?.email || '').toLowerCase() %>"
+                data-employee-id="<%= entry.employeeId.toLowerCase() %>"
+              >
+                <td>
+                  <strong><%= entry.employee?.name || entry.employeeId %></strong>
+                  <div class="muted">ID: <%= entry.employeeId %></div>
+                  <% if (entry.employee?.email) { %>
+                    <div class="muted"><%= entry.employee.email %></div>
+                  <% } %>
+                </td>
+                <td>
+                  <span><%= entry.role || entry.department || entry.employee?.department || '—' %></span>
+                  <% if (entry.department || entry.employee?.department) { %>
+                    <div class="muted">Dept: <%= entry.department || entry.employee?.department %></div>
+                  <% } %>
+                </td>
                 <td><%= entry.clockInLabel %></td>
                 <td><%= entry.clockOutLabel %></td>
                 <td><%= entry.durationLabel %></td>
                 <td><%= entry.location || '—' %></td>
-                <td><%= entry.notes || '—' %></td>
+                <td>
+                  <span class="status-chip <%= statusClass %>"><%= statusLabel %></span>
+                  <% if (entry.notes) { %>
+                    <div class="muted status-note"><%= entry.notes %></div>
+                  <% } %>
+                </td>
                 <td><button type="button" class="btn btn-outline time-adjust">Adjust</button></td>
               </tr>
             <% }) %>
           <% } else { %>
-            <tr><td colspan="7" class="muted">No entries recorded in the last week.</td></tr>
+            <tr><td colspan="8" class="muted">No entries recorded in the selected window.</td></tr>
           <% } %>
         </tbody>
       </table>
     </section>
 
     <aside class="admin-time__detail" id="time-detail" hidden>
-      <h2>Edit entry</h2>
-      <p class="muted">Adjust timestamps or metadata. Changes are logged in the audit trail.</p>
-      <form id="time-adjust-form">
-        <input type="hidden" name="_csrf" value="<%= csrfToken %>" />
-        <input type="hidden" id="time-entry-id" />
-        <label for="time-clock-in">Clock in</label>
-        <input type="datetime-local" id="time-clock-in" name="clockInAt" required />
-        <label for="time-clock-out">Clock out</label>
-        <input type="datetime-local" id="time-clock-out" name="clockOutAt" />
-        <label for="time-department">Department</label>
-        <input type="text" id="time-department" name="department" maxlength="120" />
-        <label for="time-location">Location</label>
-        <input type="text" id="time-location" name="location" maxlength="180" />
-        <label for="time-notes">Notes</label>
-        <textarea id="time-notes" name="notes" maxlength="500"></textarea>
-        <button type="submit" class="btn">Save adjustment</button>
-      </form>
+      <div class="time-detail-card">
+        <h2>Edit entry</h2>
+        <p class="muted">Adjust timestamps or metadata. Changes are logged in the audit trail.</p>
+        <form id="time-adjust-form">
+          <input type="hidden" name="_csrf" value="<%= csrfToken %>" />
+          <input type="hidden" id="time-entry-id" />
+          <label for="time-clock-in">Clock in</label>
+          <input type="datetime-local" id="time-clock-in" name="clockInAt" required />
+          <label for="time-clock-out">Clock out</label>
+          <input type="datetime-local" id="time-clock-out" name="clockOutAt" />
+          <label for="time-role">Role</label>
+          <input type="text" id="time-role" name="role" maxlength="120" />
+          <label for="time-department">Department</label>
+          <input type="text" id="time-department" name="department" maxlength="120" />
+          <label for="time-location">Location</label>
+          <input type="text" id="time-location" name="location" maxlength="180" />
+          <label for="time-notes">Notes</label>
+          <textarea id="time-notes" name="notes" maxlength="500"></textarea>
+          <div class="time-detail-actions">
+            <button type="button" class="btn btn-ghost" id="time-clockout-now">Clock out now</button>
+            <button type="submit" class="btn">Save adjustment</button>
+          </div>
+        </form>
+      </div>
+
+      <div class="time-side-panels">
+        <section class="time-panel">
+          <header>
+            <h3>Active shifts</h3>
+            <span class="muted" id="time-active-sub">Live coverage overview</span>
+          </header>
+          <ul class="time-panel__list" id="time-active-list">
+            <% if (metrics.openEntries && metrics.openEntries.length) { %>
+              <% metrics.openEntries.slice(0, 6).forEach(function(entry) { %>
+                <li data-entry-id="<%= entry.id %>">
+                  <div>
+                    <strong><%= entry.employee?.name || entry.employeeId %></strong>
+                    <div class="muted">Clocked in <%= entry.clockInLabel %></div>
+                  </div>
+                  <button type="button" class="btn btn-ghost btn-compact" data-action="clockout" data-entry-id="<%= entry.id %>">Clock out</button>
+                </li>
+              <% }) %>
+            <% } else { %>
+              <li class="muted">No active shifts right now.</li>
+            <% } %>
+          </ul>
+        </section>
+
+        <section class="time-panel">
+          <header>
+            <h3>Alerts</h3>
+            <span class="muted">Long or unclosed shifts</span>
+          </header>
+          <ul class="time-panel__list" id="time-flagged-list">
+            <% if (metrics.flagged && metrics.flagged.length) { %>
+              <% metrics.flagged.forEach(function(entry) { %>
+                <li data-entry-id="<%= entry.id %>">
+                  <div>
+                    <strong><%= entry.employee?.name || entry.employeeId %></strong>
+                    <div class="muted"><%= entry.durationLabel %> • <%= entry.clockInLabel %></div>
+                  </div>
+                </li>
+              <% }) %>
+            <% } else { %>
+              <li class="muted">All clear. No anomalies detected.</li>
+            <% } %>
+          </ul>
+        </section>
+
+        <section class="time-panel">
+          <header>
+            <h3>Coverage</h3>
+            <span class="muted">Hours per department</span>
+          </header>
+          <ul class="time-panel__list" id="time-coverage-list">
+            <% if (metrics.coverage && metrics.coverage.length) { %>
+              <% metrics.coverage.forEach(function(row) { %>
+                <li>
+                  <div>
+                    <strong><%= row.label %></strong>
+                    <div class="muted"><%= Math.round(row.minutes / 60) %>h • <%= row.count %> shifts</div>
+                  </div>
+                </li>
+              <% }) %>
+            <% } else { %>
+              <li class="muted">No recent coverage data.</li>
+            <% } %>
+          </ul>
+        </section>
+
+        <section class="time-panel">
+          <header>
+            <h3>Daily pulse</h3>
+            <span class="muted">Recent totals</span>
+          </header>
+          <ul class="time-panel__list" id="time-trend-list">
+            <% if (metrics.dailySummaries && metrics.dailySummaries.length) { %>
+              <% metrics.dailySummaries.forEach(function(row) { %>
+                <li>
+                  <div>
+                    <strong><%= new Date(row.date).toLocaleDateString() %></strong>
+                    <div class="muted"><%= Math.round(row.minutes / 60) %>h • <%= row.count %> shifts</div>
+                  </div>
+                </li>
+              <% }) %>
+            <% } else { %>
+              <li class="muted">No recent daily totals.</li>
+            <% } %>
+          </ul>
+        </section>
+      </div>
     </aside>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- enrich admin time route with employee context and timekeeping analytics for dashboards
- redesign the timekeeping console UI with insights, filters, and side panels for active shifts and alerts
- extend client functionality with advanced filtering, quick ranges, CSV export, and inline clock-out controls

## Testing
- npm test *(fails: SyntaxError: Identifier 'getRequestById' has already been declared in src/routes/adminApi.js)*

------
https://chatgpt.com/codex/tasks/task_e_68eeed5d19908323a5706756db8f189f