### PR TITLE
Handle password resets for employees without user accounts

### DIFF
--- a/src/models/users.js
+++ b/src/models/users.js
@@ -199,11 +199,13 @@ function updateUserProfile(id, updates = {}) {
   return getUserById(id);
 }
 
-function updateUserPassword(id, password) {
+function updateUserPassword(id, password, options = {}) {
   const now = new Date().toISOString();
-  db.prepare('UPDATE users SET passwordHash = ?, updatedAt = ?, mustChangePassword = 0 WHERE id = ?').run(
+  const requireChange = options.requireChange ? 1 : 0;
+  db.prepare('UPDATE users SET passwordHash = ?, updatedAt = ?, mustChangePassword = ? WHERE id = ?').run(
     bcrypt.hashSync(password, 10),
     now,
+    requireChange,
     id
   );
   return getUserById(id);


### PR DESCRIPTION
## Summary
- allow the admin reset-password endpoint to provision a user account for employees who are missing login access and flag the reset as requiring a change
- extend the user password update helper so callers can demand a must-change password flow
- cover the regression with a Jest test that exercises password resets for employees without accounts

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68eefdc63c0883239284cb3c3b56b0cd