### PR TITLE
Improve admin request payload display and status handling

### DIFF
--- a/public/css/admin-console.css
+++ b/public/css/admin-console.css
@@ -738,13 +738,47 @@ html[data-theme='light'] .admin-console {
   color: var(--admin-text-strong);
 }
 
-.request-payload pre {
+.request-payload__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.request-payload__list {
   margin: 0;
-  font-family: 'Fira Code', monospace;
-  font-size: 0.75rem;
-  color: var(--admin-status-note);
-  white-space: pre-wrap;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.request-payload__item {
+  border-radius: 0.75rem;
+  padding: 0.55rem 0.65rem;
+  background: rgba(56, 189, 248, 0.12);
+  border: 1px solid rgba(125, 211, 252, 0.35);
+}
+
+.request-payload__term {
+  margin: 0;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(186, 230, 253, 0.9);
+}
+
+.request-payload__value {
+  margin: 0.35rem 0 0;
+  font-size: 0.85rem;
+  color: var(--admin-text);
+  line-height: 1.4;
   word-break: break-word;
+}
+
+.request-payload__empty {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--admin-text);
 }
 
 .request-actions {

--- a/views/admin/requests.ejs
+++ b/views/admin/requests.ejs
@@ -109,7 +109,9 @@
               <td class="request-payload">
                 <details class="request-payload__details">
                   <summary>Inspect payload</summary>
-                  <pre><%- JSON.stringify(request.payload, null, 2) %></pre>
+                  <div class="request-payload__content" data-payload-content>
+                    <p class="request-payload__empty muted">Expand to view request details.</p>
+                  </div>
                 </details>
               </td>
               <td>


### PR DESCRIPTION
## Summary
- replace the raw JSON payload block on the admin requests table with a styled label/value layout that is populated client-side
- add shared helpers to format payload content and update table rows when filters or status changes rerender the row
- harden the status update fetch flow to handle non-JSON error responses and keep the UI state synchronized

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ef02b0130083238964d36154564f01