### PR TITLE
Normalize employee request types and extend profile support

### DIFF
--- a/public/js/admin-requests.js
+++ b/public/js/admin-requests.js
@@ -150,7 +150,8 @@ async function readAdminRequestResponse(response) {
   function toTitleCaseFromSlug(value) {
     if (!value) return '—';
     return value
-      .split('_')
+      .split(/[-_]/)
+      .filter((segment) => segment.length)
       .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
       .join(' ');
   }

--- a/scripts/seed.js
+++ b/scripts/seed.js
@@ -303,7 +303,7 @@ function resetSchema() {
       id TEXT PRIMARY KEY,
       employeeId TEXT NOT NULL REFERENCES employees(id) ON DELETE CASCADE,
       userId TEXT REFERENCES users(id) ON DELETE SET NULL,
-      type TEXT NOT NULL CHECK(type IN ('pto','workers-comp','resignation','transfer')),
+      type TEXT NOT NULL CHECK(type IN ('pto','workers-comp','resignation','transfer','profile-update')),
       payload TEXT,
       status TEXT NOT NULL CHECK(status IN ('pending','approved','denied')) DEFAULT 'pending',
       comment TEXT,

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -385,7 +385,8 @@ router.get('/admin/requests', ensureAdmin, (req, res) => {
       const submittedAt = request.createdAt ? new Date(request.createdAt) : null;
       const typeLabel = request.type
         ? request.type
-            .split('_')
+            .split(/[-_]/)
+            .filter((segment) => segment.length)
             .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
             .join(' ')
         : '—';

--- a/views/admin/requests.ejs
+++ b/views/admin/requests.ejs
@@ -74,8 +74,8 @@
         <select id="request-filter-type">
           <option value="">All</option>
           <option value="pto">PTO</option>
-          <option value="workers_comp">Workers' Comp</option>
-          <option value="profile_update">Profile Update</option>
+          <option value="workers-comp">Workers' Comp</option>
+          <option value="profile-update">Profile Update</option>
         </select>
       </label>
       <button class="btn" id="request-filter-apply" type="button">Apply</button>


### PR DESCRIPTION
## Summary
- normalize employee request types and migrate existing rows to canonical slugs including profile updates
- harden employee and admin request flows with validation-aware error handling and consistent type comparisons
- align admin filters, labels, and seed data with the updated request types

## Testing
- npm test -- --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68ef050f7c948323baec9c27e3bf50d4