### PR TITLE
Ensure live chat production readiness

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -4005,6 +4005,34 @@ body.chat-sidebar-open {
   color: var(--color-muted);
 }
 
+.chat-uploading-indicator {
+  font-size: 0.75rem;
+  color: var(--color-muted);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.chat-uploading-indicator::before {
+  content: '';
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  border: 2px solid rgba(94, 252, 255, 0.35);
+  border-top-color: rgba(94, 252, 255, 0.9);
+  animation: chat-spinner 0.9s linear infinite;
+}
+
+.chat-uploading-indicator[hidden] {
+  display: none !important;
+}
+
+@keyframes chat-spinner {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .chat-upload {
   position: relative;
   width: 44px;

--- a/src/server.js
+++ b/src/server.js
@@ -54,6 +54,7 @@ function addOriginVariants(origin, set) {
 const allowedOrigins = new Set();
 addOriginVariants(`http://localhost:${PORT}`, allowedOrigins);
 addOriginVariants(`http://127.0.0.1:${PORT}`, allowedOrigins);
+addOriginVariants('https://gpt-codex-hotel.onrender.com', allowedOrigins);
 
 if (process.env.SOCKET_ORIGIN) {
   addOriginVariants(process.env.SOCKET_ORIGIN, allowedOrigins);
@@ -70,6 +71,7 @@ if (process.env.RENDER_EXTERNAL_URL) {
 }
 
 const io = new Server(server, {
+  maxHttpBufferSize: 6 * 1024 * 1024,
   cors: {
     origin: (origin, callback) => {
       if (!origin || allowedOrigins.has(origin)) {
@@ -90,7 +92,7 @@ io.use((socket, next) => {
 const onlineUsers = new Map();
 const recentMessageTimestamps = new Map();
 const bannedWords = ['damn', 'hell', 'shit'];
-const MAX_ATTACHMENT_SIZE = 10 * 1024 * 1024; // 10 MB
+const MAX_ATTACHMENT_SIZE = 5 * 1024 * 1024; // 5 MB
 
 function emitToUser(userId, event, payload) {
   const sockets = onlineUsers.get(userId);
@@ -291,7 +293,7 @@ io.on('connection', (socket) => {
           return callback?.({ error: 'Attachment could not be processed.' });
         }
         if (fileBuffer.length > MAX_ATTACHMENT_SIZE) {
-          return callback?.({ error: 'Attachment exceeds the 10 MB limit.' });
+          return callback?.({ error: 'Attachment exceeds the 5 MB limit.' });
         }
         const encryptedForTransit = Boolean(encrypted);
         fileName = typeof name === 'string' && name.trim().length > 0 ? name.trim().slice(0, 160) : 'attachment';

--- a/views/chat/index.ejs
+++ b/views/chat/index.ejs
@@ -88,7 +88,8 @@
       </div>
       <div class="chat-composer-actions">
         <span class="chat-file-indicator" data-file-indicator hidden>No file selected</span>
-        <button class="cta-button primary" type="submit">Send</button>
+        <span class="chat-uploading-indicator" data-uploading-indicator hidden aria-live="polite"></span>
+        <button class="cta-button primary" type="submit" data-submit-button>Send</button>
       </div>
     </form>
   </div>


### PR DESCRIPTION
## Summary
- allow the Render production domain and larger Socket.IO buffers while enforcing a 5 MB attachment ceiling server-side
- add client-side attachment guards, prefer WebSocket transport, and surface upload state while messages are pending
- style the chat composer to show a spinner-based uploading indicator next to the send button

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910ec2d86e4832383f20378acf18f90)